### PR TITLE
Fix space between discounted and old price

### DIFF
--- a/src/assets/scss/_shop-item.scss
+++ b/src/assets/scss/_shop-item.scss
@@ -49,6 +49,7 @@
     font-weight: 700;
     .strikethrough {
       text-decoration: line-through;
+      padding-right: 10px;
     }
     .pop-item-price-old {
       color: $valencia;


### PR DESCRIPTION
Fixed the space between discounted price and old price with padding

<img width="253" alt="screen shot 2018-09-28 at 14 51 51" src="https://user-images.githubusercontent.com/31618523/46209399-0edbd500-c32e-11e8-9c44-8b4ec1154bac.png">
