### PR TITLE
Improve header at media screen

### DIFF
--- a/src/assets/scss/_navigation.scss
+++ b/src/assets/scss/_navigation.scss
@@ -103,7 +103,6 @@
 
   .list-item-store {
     float: left;
-
     .store-select {
       color: $white;
       padding: 10px 10px;
@@ -134,6 +133,9 @@
           margin-right: 3px;
         }
       }
+    }
+    @media screen and (max-width: 767px) {
+      display: none;
     }
   }
 
@@ -203,10 +205,18 @@
 
   .list-item-location {
     float: right;
-    display: none;
     img {
       height: 20px;
       margin-right: 10px;
+      &.pull-right{
+        @media screen and (max-width: 767px) {
+          float: none !important;
+        }
+      }
+      @media screen and (max-width: 767px){
+       height: 25px;
+       margin: 0; 
+      }
     }
     .location-dropdown {
       position: relative;

--- a/src/assets/scss/_navigation.scss
+++ b/src/assets/scss/_navigation.scss
@@ -214,8 +214,8 @@
         }
       }
       @media screen and (max-width: 767px){
-       height: 25px;
-       margin: 0; 
+        height: 25px;
+        margin: 0; 
       }
     }
     .location-dropdown {

--- a/src/components/footer/TheFooter.vue
+++ b/src/components/footer/TheFooter.vue
@@ -7,7 +7,12 @@
             <div class="footer-col">
               <ul>
                 <li class="footer-title hidden-xs">{{ $t("customerCare") }}</li>
-                <li><a href="#">{{ $t("contactUs") }}</a></li>
+                <li>
+                  <a href="tel:0044123456000"
+                   class="link-hotline">
+                   {{ $t("callUs") }}
+                  </a>
+                </li>
                 <li><a href="#">{{ $t("help") }}</a></li>
                 <li><a href="#">{{ $t("shipping") }}</a></li>
                 <li><a href="#">{{ $t("returns") }}</a></li>
@@ -112,6 +117,7 @@ en:
   imprint: "Imprint"
   privacyPolicy: "Privacy policy"
   termsOfUse: "Terms of use"
+  callUs: "Call us on +44 123 456 000"
 de:
   paySecure: "Sicher zahlen"
   followUs: "Follow us"
@@ -133,4 +139,5 @@ de:
   imprint: "Impressum"
   privacyPolicy: "Datenschutz"
   termsOfUse: "AGB"
+  callUs: "Rufen Sie uns auf +44 123 456 000 an"
 </i18n>

--- a/src/components/footer/TheFooter.vue
+++ b/src/components/footer/TheFooter.vue
@@ -7,12 +7,7 @@
             <div class="footer-col">
               <ul>
                 <li class="footer-title hidden-xs">{{ $t("customerCare") }}</li>
-                <li>
-                  <a href="tel:0044123456000"
-                   class="link-hotline">
-                   {{ $t("callUs") }}
-                  </a>
-                </li>
+                <li><a href="#">{{ $t("contactUs") }}</a></li>
                 <li><a href="#">{{ $t("help") }}</a></li>
                 <li><a href="#">{{ $t("shipping") }}</a></li>
                 <li><a href="#">{{ $t("returns") }}</a></li>
@@ -117,7 +112,6 @@ en:
   imprint: "Imprint"
   privacyPolicy: "Privacy policy"
   termsOfUse: "Terms of use"
-  callUs: "Call us on +44 123 456 000"
 de:
   paySecure: "Sicher zahlen"
   followUs: "Follow us"
@@ -139,5 +133,4 @@ de:
   imprint: "Impressum"
   privacyPolicy: "Datenschutz"
   termsOfUse: "AGB"
-  callUs: "Rufen Sie uns auf +44 123 456 000 an"
 </i18n>

--- a/src/components/header/TheHeader.vue
+++ b/src/components/header/TheHeader.vue
@@ -42,13 +42,6 @@
                 </a>
               </li>
 
-              <li class="list-item-call">
-                <a href="tel:0044123456000"
-                   class="link-hotline">
-                  {{ $t("callUs") }}
-                </a>
-              </li>
-
               <MiniCart/>
               <LoginButton/>
               <LocationSelector/>
@@ -119,10 +112,8 @@ en:
   search: "Search"
   stores: "Stores"
   help: "Help"
-  callUs: "Call us on +44 123 456 000"
 de:
   search: "Suche"
   stores: "Filiale"
   help: "Hilfe"
-  callUs: "Rufen Sie uns auf +44 123 456 000 an"
 </i18n>


### PR DESCRIPTION
* Replaced stores with language selector in the header at mobile version.
* Moved `CALL US ON +44 123 456 000` in header to footer (instead of `CONTACT US`) as it is the reason that messes up the language selector (sentence too long)