### PR TITLE
Fix bug with cleaning up store, missing to clean token

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -25,6 +25,7 @@ const tokenProvider = new TokenProvider({
 }, storedTokenInfo);
 
 function cleanUpSession() {
+  localStorage.removeItem(tokenInfoStorageName);
   localStorage.removeItem(isAuthenticatedStorageName);
   return store.dispatch('setAuthenticated', false);
 }


### PR DESCRIPTION
Seems like I forgot to remove the token info too. So once you got stuck with an invalid token, you wouldn't get rid of it unless cleaning up manually.