### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -11,6 +11,105 @@
       "types": [
         {
           "kind": "OBJECT",
+          "name": "APIClientWithSecret",
+          "description": "API Clients can be used to obtain OAuth 2 access tokens. The secret is only shown once in the response of creating the API Client.",
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scope",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastUsedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "secret",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "AbsoluteDiscountValue",
           "description": null,
           "fields": [
@@ -105,6 +204,29 @@
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "ActiveCartInterface",
+          "description": "A field to access the active cart.",
+          "fields": [
+            {
+              "name": "activeCart",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "AddCartCustomLineItem",
           "description": null,
@@ -155,7 +277,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -588,6 +710,31 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "AddCustomerStore",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "store",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "AddInventoryEntryQuantity",
           "description": null,
           "fields": null,
@@ -601,31 +748,6 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Long",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
-          "name": "AddLocation",
-          "description": null,
-          "fields": null,
-          "inputFields": [
-            {
-              "name": "location",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "ZoneLocation",
                   "ofType": null
                 }
               },
@@ -724,6 +846,229 @@
             },
             {
               "name": "productId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddOrderDelivery",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DeliveryItemDraftType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": "[]"
+            },
+            {
+              "name": "parcels",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DeliveryItemDraftType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": "[]"
+            },
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddressInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddOrderItemShippingAddress",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AddressInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddOrderParcelToDelivery",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "deliveryId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "measurements",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ParcelMeasurementsDraftType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "trackingData",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "TrackingDataDraftType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "DeliveryItemDraftType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": "[]"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddOrderPayment",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "payment",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddOrderReturnInfo",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ReturnItemDraftType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "returnDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "returnTrackingId",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -1104,7 +1449,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "ReferenceInput",
+                  "name": "ResourceIdentifierInput",
                   "ofType": null
                 }
               },
@@ -1143,7 +1488,32 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "ReferenceInput",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "AddZoneLocation",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "location",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ZoneLocation",
                   "ofType": null
                 }
               },
@@ -2614,6 +2984,16 @@
                 "ofType": null
               },
               "defaultValue": null
+            },
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -2798,6 +3178,16 @@
               "defaultValue": null
             },
             {
+              "name": "setKey",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetCartDiscountKey",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "setValidFrom",
               "description": null,
               "type": {
@@ -2968,7 +3358,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -3154,6 +3544,16 @@
                 "ofType": null
               },
               "defaultValue": "Customer"
+            },
+            {
+              "name": "store",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ResourceIdentifierInput",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -5098,6 +5498,81 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "ChangeOrderPaymentState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "paymentState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "PaymentState",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ChangeOrderShipmentState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "shipmentState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ShipmentState",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ChangeOrderState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "orderState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderState",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "ChangeProductAssetName",
           "description": null,
           "fields": null,
@@ -6054,7 +6529,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -6128,6 +6603,88 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "CreateApiClient",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "scope",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "CreateStore",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LocalizedStringItemInputType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "CreateZone",
           "description": null,
           "fields": null,
@@ -6143,6 +6700,16 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             },
@@ -6201,7 +6768,7 @@
             },
             {
               "name": "value",
-              "description": null,
+              "description": "The value of this custom field as escaped JSON., based on the FieldDefinition of the Type.\n\nExamples:\n\n* FieldType `String`: `\"\\\"This is a string\\\"\"`\n* FieldType `Number`: `\"4\"`\n* FieldType `Set` with an elementType of `String`: `\"[\\\"This is a string\\\", \\\"This is another string\\\"]\"`\n* FieldType `Reference`: `\"{\\\"id\\\", \\\"b911b62d-353a-4388-93ee-8d488d9af962\\\", \\\"typeId\\\", \\\"product\\\"}\"`\n",
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
@@ -6385,6 +6952,163 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "CustomLineItemReturnItem",
+          "description": null,
+          "fields": [
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnShipmentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnPaymentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "ReturnItem",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -7270,6 +7994,24 @@
                 "ofType": null
               },
               "defaultValue": null
+            },
+            {
+              "name": "stores",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ResourceIdentifierInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -7404,6 +8146,16 @@
               "defaultValue": null
             },
             {
+              "name": "addStore",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddCustomerStore",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "changeAddress",
               "description": null,
               "type": {
@@ -7449,6 +8201,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "RemoveCustomerShippingAddressId",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeStore",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveCustomerStore",
                 "ofType": null
               },
               "defaultValue": null
@@ -7599,6 +8361,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "SetCustomerSalutation",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setStores",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetCustomerStores",
                 "ofType": null
               },
               "defaultValue": null
@@ -7953,6 +8725,45 @@
               "ofType": null
             }
           ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeliveryItemDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
           "enumValues": null,
           "possibleTypes": null
         },
@@ -8812,6 +9623,45 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "ExternalOAuthDraft",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "url",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "authorizationHeader",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "ExternalTaxAmountDraft",
           "description": null,
           "fields": null,
@@ -8924,6 +9774,16 @@
                 }
               },
               "defaultValue": "[]"
+            },
+            {
+              "name": "includedInPrice",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
             }
           ],
           "interfaces": null,
@@ -9289,6 +10149,100 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "ImportOrderCustomLineItemState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ItemStateDraftType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ImportOrderLineItemState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "lineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ItemStateDraftType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "InventoryEntryDraft",
           "description": null,
           "fields": null,
@@ -9342,7 +10296,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -9488,6 +10442,78 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "ItemShippingDetailsDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "targets",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ShippingTargetDraftType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ItemStateDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ReferenceInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "LineItemDraft",
           "description": null,
           "fields": null,
@@ -9604,6 +10630,163 @@
             }
           ],
           "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "LineItemReturnItem",
+          "description": null,
+          "fields": [
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lineItemId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnShipmentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnPaymentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "ReturnItem",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -9865,7 +11048,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -10065,7 +11248,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -10141,7 +11324,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -10274,7 +11457,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -10444,7 +11627,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -10504,7 +11687,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -11408,26 +12591,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -11462,20 +12625,7 @@
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "CustomerGroup",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteCustomerGroup",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -11495,7 +12645,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerGroup",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteCustomerGroup",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -11507,6 +12670,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -11551,26 +12734,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -11605,20 +12768,7 @@
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Category",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteCategory",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -11638,7 +12788,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Category",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteCategory",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -11650,6 +12813,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -11694,26 +12877,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -11748,20 +12911,7 @@
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "ProductTypeDefinition",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteProductType",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -11781,7 +12931,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProductTypeDefinition",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteProductType",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -11793,6 +12956,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -11837,26 +13020,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -11884,27 +13047,14 @@
                         "name": null,
                         "ofType": {
                           "kind": "INPUT_OBJECT",
-                          "name": "UpdateShippingMethodAction",
+                          "name": "ShippingMethodUpdateAction",
                           "ofType": null
                         }
                       }
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "ShippingMethod",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteShippingMethod",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -11924,7 +13074,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ShippingMethod",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteShippingMethod",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -11936,6 +13099,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -11980,20 +13163,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12028,6 +13197,26 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -12043,20 +13232,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12067,6 +13242,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -12111,26 +13306,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12165,20 +13340,7 @@
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "TaxCategory",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteTaxCategory",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -12198,7 +13360,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TaxCategory",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteTaxCategory",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -12210,6 +13385,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -12385,20 +13580,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12433,6 +13614,26 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -12448,20 +13649,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12472,6 +13659,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -12516,20 +13723,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12564,6 +13757,26 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -12579,20 +13792,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12603,6 +13802,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -12647,26 +13866,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12701,20 +13900,7 @@
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Product",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteProduct",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -12734,7 +13920,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Product",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteProduct",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -12746,6 +13945,26 @@
                       "name": "Long",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -12825,26 +14044,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "version",
                   "description": null,
                   "type": {
@@ -12879,20 +14078,7 @@
                     }
                   },
                   "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Customer",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "deleteCustomer",
-              "description": null,
-              "args": [
+                },
                 {
                   "name": "id",
                   "description": "Queries with specified ID",
@@ -12912,7 +14098,20 @@
                     "ofType": null
                   },
                   "defaultValue": null
-                },
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteCustomer",
+              "description": null,
+              "args": [
                 {
                   "name": "version",
                   "description": null,
@@ -12936,6 +14135,26 @@
                     "ofType": null
                   },
                   "defaultValue": "false"
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -13614,6 +14833,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -13677,6 +14906,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -13728,6 +14967,16 @@
                     "ofType": null
                   },
                   "defaultValue": "false"
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -13780,6 +15029,16 @@
                       "name": "MyCartDraft",
                       "ofType": null
                     }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -13845,6 +15104,16 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
@@ -13886,11 +15155,241 @@
                     }
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
                 "kind": "OBJECT",
                 "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createOrderFromCart",
+              "description": null,
+              "args": [
+                {
+                  "name": "draft",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "OrderCartCommand",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updateOrder",
+              "description": null,
+              "args": [
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Long",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "actions",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "OrderUpdateAction",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteOrder",
+              "description": null,
+              "args": [
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Long",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "personalDataErasure",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false"
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createMyOrderFromCart",
+              "description": null,
+              "args": [
+                {
+                  "name": "draft",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "OrderMyCartCommand",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "storeKey",
+                  "description": "Beta feature. The mutation is only performed if the resource is part of the store. Can be used with store-specific OAuth permissions.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "KeyReferenceInput",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -13940,6 +15439,203 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ProjectProjection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createStore",
+              "description": null,
+              "args": [
+                {
+                  "name": "draft",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateStore",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "updateStore",
+              "description": null,
+              "args": [
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Long",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "actions",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "StoreUpdateAction",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "deleteStore",
+              "description": null,
+              "args": [
+                {
+                  "name": "version",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "Long",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "createApiClient",
+              "description": null,
+              "args": [
+                {
+                  "name": "draft",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateApiClient",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "APIClientWithSecret",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deleteApiClient",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "APIClientWithoutSecret",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -14046,7 +15742,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -14937,6 +16633,596 @@
           "possibleTypes": null
         },
         {
+          "kind": "INPUT_OBJECT",
+          "name": "OrderCartCommand",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "paymentState",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "PaymentState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "orderState",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "OrderState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ReferenceInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "ShipmentState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "orderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "OrderMyCartCommand",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "OrderUpdateAction",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addDelivery",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddOrderDelivery",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addItemShippingAddress",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddOrderItemShippingAddress",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addParcelToDelivery",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddOrderParcelToDelivery",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addPayment",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddOrderPayment",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addReturnInfo",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddOrderReturnInfo",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changeOrderState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChangeOrderState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changePaymentState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChangeOrderPaymentState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changeShipmentState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChangeOrderShipmentState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "importCustomLineItemState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ImportOrderCustomLineItemState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "importLineItemState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ImportOrderLineItemState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeDelivery",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveOrderDelivery",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeItemShippingAddress",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveOrderItemShippingAddress",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeParcelFromDelivery",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveOrderParcelFromDelivery",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removePayment",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveOrderPayment",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setBillingAddress",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderBillingAddress",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomField",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomField",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomLineItemCustomField",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomLineItemCustomField",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomLineItemCustomType",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomLineItemCustomType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomLineItemShippingDetails",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomLineItemShippingDetails",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomType",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomerEmail",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomerEmail",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setCustomerId",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderCustomerId",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setDeliveryAddress",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderDeliveryAddress",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setDeliveryItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderDeliveryItems",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setLineItemCustomField",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderLineItemCustomField",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setLineItemCustomType",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderLineItemCustomType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setLineItemShippingDetails",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderLineItemShippingDetails",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setLocale",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderLocale",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setOrderNumber",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderNumber",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setParcelItems",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderParcelItems",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setParcelMeasurements",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderParcelMeasurements",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setParcelTrackingData",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderParcelTrackingData",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setReturnPaymentState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderReturnPaymentState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setReturnShipmentState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderReturnShipmentState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setShippingAddress",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetOrderShippingAddress",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "transitionCustomLineItemState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "TransitionOrderCustomLineItemState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "transitionLineItemState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "TransitionOrderLineItemState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "transitionState",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "TransitionOrderState",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updateItemShippingAddress",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "UpdateOrderItemShippingAddress",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "updateSyncInfo",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "UpdateOrderSyncInfo",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ParcelMeasurementsDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "heightInMillimeter",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lengthInMillimeter",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "widthInMillimeter",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "weightInGram",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "OBJECT",
           "name": "PlainEnumValue",
           "description": null,
@@ -15331,6 +17617,16 @@
                 "ofType": null
               },
               "defaultValue": "true"
+            },
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -15399,6 +17695,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "SetProductDiscountDescription",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setKey",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetProductDiscountKey",
                 "ofType": null
               },
               "defaultValue": null
@@ -15694,7 +18000,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -15787,7 +18093,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -16104,6 +18410,16 @@
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "changeAttributeOrder",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changeAttributeOrderByName",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "changeAttributeOrderByName",
                 "ofType": null
               },
               "defaultValue": null
@@ -16854,6 +19170,16 @@
               "defaultValue": null
             },
             {
+              "name": "setExternalOAuth",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetProjectSettingsExternalOAuth",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "setShippingRateInputType",
               "description": null,
               "type": {
@@ -17577,6 +19903,31 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "RemoveCustomerStore",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "store",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "RemoveInventoryEntryQuantity",
           "description": null,
           "fields": null,
@@ -17602,19 +19953,94 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "RemoveLocation",
+          "name": "RemoveOrderDelivery",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "location",
+              "name": "deliveryId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RemoveOrderItemShippingAddress",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addressKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RemoveOrderParcelFromDelivery",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "parcelId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RemoveOrderPayment",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "payment",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "ZoneLocation",
+                  "name": "ResourceIdentifierInput",
                   "ofType": null
                 }
               },
@@ -17912,7 +20338,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "ReferenceInput",
+                  "name": "ResourceIdentifierInput",
                   "ofType": null
                 }
               },
@@ -17951,7 +20377,32 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "ReferenceInput",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "RemoveZoneLocation",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "location",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ZoneLocation",
                   "ofType": null
                 }
               },
@@ -17995,6 +20446,75 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ReturnItemDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "lineItemId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnShipmentState",
+                  "ofType": null
+                }
               },
               "defaultValue": null
             }
@@ -18606,7 +21126,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -18884,6 +21404,27 @@
                     "ofType": null
                   }
                 }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetCartDiscountKey",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null
             }
@@ -19315,7 +21856,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -20489,6 +23030,39 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "SetCustomerStores",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "stores",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "ResourceIdentifierInput",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "SetCustomerTitle",
           "description": null,
           "fields": null,
@@ -20964,7 +23538,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -20985,7 +23559,818 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderBillingAddress",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddressInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomField",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomLineItemCustomField",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomLineItemCustomType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CustomFieldInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ResourceIdentifierInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "typeKey",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "typeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomLineItemShippingDetails",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingDetails",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ItemShippingDetailsDraftType",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "fields",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CustomFieldInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ResourceIdentifierInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "typeKey",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "typeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomerEmail",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "email",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderCustomerId",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customerId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderDeliveryAddress",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "deliveryId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddressInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderDeliveryItems",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "deliveryId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeliveryItemDraftType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderLineItemCustomField",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "lineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "value",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderLineItemCustomType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "lineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "CustomFieldInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ResourceIdentifierInput",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "typeKey",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "typeId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderLineItemShippingDetails",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "lineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shippingDetails",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ItemShippingDetailsDraftType",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderLocale",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "locale",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Locale",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderNumber",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "orderNumber",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderParcelItems",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "parcelId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "items",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "DeliveryItemDraftType",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderParcelMeasurements",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "parcelId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "measurements",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ParcelMeasurementsDraftType",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderParcelTrackingData",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "parcelId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "trackingData",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "TrackingDataDraftType",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderReturnPaymentState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "returnItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "paymentState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnPaymentState",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderReturnShipmentState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "returnItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnShipmentState",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetOrderShippingAddress",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "address",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddressInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -21776,6 +25161,27 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "SetProductDiscountKey",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "key",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "SetProductDiscountValidFrom",
           "description": null,
           "fields": null,
@@ -22471,7 +25877,7 @@
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "ReferenceInput",
+                "name": "ResourceIdentifierInput",
                 "ofType": null
               },
               "defaultValue": null
@@ -22526,6 +25932,27 @@
                 "ofType": null
               },
               "defaultValue": "true"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetProjectSettingsExternalOAuth",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "externalOAuth",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ExternalOAuthDraft",
+                "ofType": null
+              },
+              "defaultValue": null
             }
           ],
           "interfaces": null,
@@ -22661,6 +26088,35 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "SetStoreName",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "name",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "LocalizedStringItemInputType",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "SetTaxCategoryKey",
           "description": null,
           "fields": null,
@@ -22737,6 +26193,27 @@
           "inputFields": [
             {
               "name": "description",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "SetZoneKey",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "key",
               "description": null,
               "type": {
                 "kind": "SCALAR",
@@ -22842,6 +26319,117 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ShippingMethodUpdateAction",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addShippingRate",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddShippingMethodShippingRate",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "addZone",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddShippingMethodZone",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changeIsDefault",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChangeShippingMethodIsDefault",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changeName",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChangeShippingMethodName",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "changeTaxCategory",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChangeShippingMethodTaxCategory",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeShippingRate",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveShippingMethodShippingRate",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeZone",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveShippingMethodZone",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setDescription",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetShippingMethodDescription",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setKey",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetShippingMethodKey",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "setPredicate",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetShippingMethodPredicate",
                 "ofType": null
               },
               "defaultValue": null
@@ -23201,7 +26789,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -23545,6 +27133,45 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "ShippingTargetDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "addressKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "ShippingTargetInput",
           "description": null,
           "fields": null,
@@ -23576,6 +27203,27 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "StoreUpdateAction",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "setName",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "SetStoreName",
                 "ofType": null
               },
               "defaultValue": null
@@ -24373,6 +28021,256 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "TrackingDataDraftType",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "trackingId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "carrier",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "provider",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "providerTransaction",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "isReturn",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TransitionOrderCustomLineItemState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "customLineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fromState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "toState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "actualTransitionDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TransitionOrderLineItemState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "lineItemId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "fromState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "toState",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "actualTransitionDate",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "TransitionOrderState",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "state",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "force",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": "false"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "TransitionProductState",
           "description": null,
           "fields": null,
@@ -24454,106 +28352,65 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "UpdateShippingMethodAction",
+          "name": "UpdateOrderItemShippingAddress",
           "description": null,
           "fields": null,
           "inputFields": [
             {
-              "name": "changeName",
+              "name": "address",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ChangeShippingMethodName",
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "AddressInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "UpdateOrderSyncInfo",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "channel",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "ResourceIdentifierInput",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "syncedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
                 "ofType": null
               },
               "defaultValue": null
             },
             {
-              "name": "setDescription",
+              "name": "externalId",
               "description": null,
               "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "SetShippingMethodDescription",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "changeTaxCategory",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ChangeShippingMethodTaxCategory",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "changeIsDefault",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "ChangeShippingMethodIsDefault",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addShippingRate",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "AddShippingMethodShippingRate",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "removeShippingRate",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "RemoveShippingMethodShippingRate",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "addZone",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "AddShippingMethodZone",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "removeZone",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "RemoveShippingMethodZone",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setKey",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "SetShippingMethodKey",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "setPredicate",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "SetShippingMethodPredicate",
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null
@@ -24633,7 +28490,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "INPUT_OBJECT",
-                  "name": "ReferenceInput",
+                  "name": "ResourceIdentifierInput",
                   "ofType": null
                 }
               },
@@ -24669,11 +28526,31 @@
           "fields": null,
           "inputFields": [
             {
+              "name": "addLocation",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "AddZoneLocation",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
               "name": "changeName",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
                 "name": "ChangeZoneName",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "removeLocation",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "RemoveZoneLocation",
                 "ofType": null
               },
               "defaultValue": null
@@ -24689,21 +28566,11 @@
               "defaultValue": null
             },
             {
-              "name": "addLocation",
+              "name": "setKey",
               "description": null,
               "type": {
                 "kind": "INPUT_OBJECT",
-                "name": "AddLocation",
-                "ofType": null
-              },
-              "defaultValue": null
-            },
-            {
-              "name": "removeLocation",
-              "description": null,
-              "type": {
-                "kind": "INPUT_OBJECT",
-                "name": "RemoveLocation",
+                "name": "SetZoneKey",
                 "ofType": null
               },
               "defaultValue": null
@@ -24876,6 +28743,39 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "AttributeDefinitionDraft",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "changeAttributeOrderByName",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "attributeNames",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
                       "ofType": null
                     }
                   }
@@ -25808,6 +29708,172 @@
         },
         {
           "kind": "OBJECT",
+          "name": "APIClientWithoutSecret",
+          "description": "API Clients can be used to obtain OAuth 2 access tokens",
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "scope",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastUsedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "APIClientWithoutSecretQueryResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "offset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "results",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "APIClientWithoutSecret",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "Address",
           "description": "An address represents a postal address.",
           "fields": [
@@ -26211,7 +30277,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -26276,7 +30342,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -26414,7 +30480,7 @@
             },
             {
               "name": "customFields",
-              "description": "Custom fields",
+              "description": "This field would contain type data",
               "args": [],
               "type": {
                 "kind": "INTERFACE",
@@ -26754,7 +30820,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -26827,7 +30893,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -27204,38 +31270,6 @@
           "description": "A shopping cart holds product variants and can be ordered. Each cart either belongs to a registered customer or is an anonymous cart.",
           "fields": [
             {
-              "name": "id",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "version",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Long",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "customerId",
               "description": null,
               "args": [],
@@ -27355,22 +31389,6 @@
                 "kind": "OBJECT",
                 "name": "TaxedPrice",
                 "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "cartState",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "CartState",
-                  "ofType": null
-                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -27584,6 +31602,122 @@
               "deprecationReason": null
             },
             {
+              "name": "paymentInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Locale",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingRateInput",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "ShippingRateInput",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "origin",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CartOrigin",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "storeRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "store",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "itemShippingAddresses",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Address",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cartState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CartState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "customFieldsRaw",
               "description": "This field contains non-typed data. Consider using `customFields` as a typed alternative.",
               "args": [
@@ -27641,24 +31775,12 @@
               "deprecationReason": null
             },
             {
-              "name": "paymentInfo",
-              "description": null,
+              "name": "customFields",
+              "description": "This field would contain type data",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "PaymentInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "locale",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Locale",
+                "kind": "INTERFACE",
+                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27677,27 +31799,31 @@
               "deprecationReason": null
             },
             {
-              "name": "shippingRateInput",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "ShippingRateInput",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "origin",
+              "name": "id",
               "description": null,
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "ENUM",
-                  "name": "CartOrigin",
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
                   "ofType": null
                 }
               },
@@ -27737,36 +31863,24 @@
               "deprecationReason": null
             },
             {
-              "name": "itemShippingAddresses",
+              "name": "createdBy",
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "OBJECT",
-                      "name": "Address",
-                      "ofType": null
-                    }
-                  }
-                }
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "customFields",
-              "description": "Custom fields",
+              "name": "lastModifiedBy",
+              "description": null,
               "args": [],
               "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
+                "kind": "OBJECT",
+                "name": "Initiator",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -27831,7 +31945,13 @@
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Versioned",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -27945,12 +32065,24 @@
               "deprecationReason": null
             },
             {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -27991,7 +32123,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -28128,6 +32260,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "value",
               "description": null,
               "args": [],
@@ -28238,18 +32382,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Initiator",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -28527,6 +32659,120 @@
           "possibleTypes": null
         },
         {
+          "kind": "INTERFACE",
+          "name": "CartQueryInterface",
+          "description": "Fields to access carts. Includes direct access to a single cart and searching for carts.",
+          "fields": [
+            {
+              "name": "cart",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "carts",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CartQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "InStore",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Query",
+              "ofType": null
+            }
+          ]
+        },
+        {
           "kind": "OBJECT",
           "name": "CartQueryResult",
           "description": null,
@@ -28693,7 +32939,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -28758,7 +33004,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -28819,7 +33065,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -28984,7 +33230,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -29025,7 +33271,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -29066,7 +33312,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -29283,6 +33529,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createdBy",
               "description": null,
               "args": [],
@@ -29301,18 +33559,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Initiator",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -29535,12 +33781,40 @@
               "deprecationReason": null
             },
             {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -29605,7 +33879,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -29666,7 +33940,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -29978,8 +34252,65 @@
               "deprecationReason": null
             },
             {
+              "name": "customFieldsRaw",
+              "description": "This field contains non-typed data. Consider using `customFields` as a typed alternative.",
+              "args": [
+                {
+                  "name": "includeNames",
+                  "description": "The names of the custom fields to include.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "excludeNames",
+                  "description": "The names of the custom fields to exclude.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RawCustomField",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "customFields",
-              "description": "Custom fields",
+              "description": "This field would contain type data",
               "args": [],
               "type": {
                 "kind": "INTERFACE",
@@ -30218,7 +34549,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -30279,7 +34610,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -30431,6 +34762,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -30725,7 +35068,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -30990,24 +35333,24 @@
               "deprecationReason": null
             },
             {
-              "name": "shippingDetails",
-              "description": null,
+              "name": "customFields",
+              "description": "This field would contain type data",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "ItemShippingDetails",
+                "kind": "INTERFACE",
+                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "customFields",
-              "description": "Custom fields",
+              "name": "shippingDetails",
+              "description": null,
               "args": [],
               "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
+                "kind": "OBJECT",
+                "name": "ItemShippingDetails",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -31274,42 +35617,6 @@
               "deprecationReason": null
             },
             {
-              "name": "dateOfBirth",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Date",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "companyName",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "vatId",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "firstName",
               "description": null,
               "args": [],
@@ -31371,6 +35678,42 @@
             },
             {
               "name": "salutation",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "dateOfBirth",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Date",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "companyName",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "vatId",
               "description": null,
               "args": [],
               "type": {
@@ -31466,6 +35809,54 @@
               "deprecationReason": null
             },
             {
+              "name": "storesRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "KeyReference",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "stores",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Store",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
               "name": "customFieldsRaw",
               "description": "This field contains non-typed data. Consider using `customFields` as a typed alternative.",
               "args": [
@@ -31518,6 +35909,18 @@
                     "ofType": null
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -31611,18 +36014,6 @@
               "deprecationReason": null
             },
             {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "customFieldList",
               "description": "Custom fields are returned as a list instead of an object structure.",
               "args": [
@@ -31690,6 +36081,55 @@
           ],
           "enumValues": null,
           "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "CustomerActiveCartInterface",
+          "description": "A field to access a customer's active cart.",
+          "fields": [
+            {
+              "name": "customerActiveCart",
+              "description": null,
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "InStore",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Query",
+              "ofType": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",
@@ -31846,6 +36286,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "createdBy",
               "description": null,
               "args": [],
@@ -31864,18 +36316,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Initiator",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -32464,7 +36904,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -32505,7 +36945,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -32536,6 +36976,30 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cartDiscounts",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CartDiscount",
+                      "ofType": null
+                    }
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -32638,6 +37102,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "applicationCount",
               "description": "How many times this discount code was applied (only applications that were part of a successful checkout are considered)",
               "args": [],
@@ -32654,7 +37130,7 @@
               "deprecationReason": null
             },
             {
-              "name": "cartDiscounts",
+              "name": "cartDiscountRefs",
               "description": null,
               "args": [],
               "type": {
@@ -32668,7 +37144,7 @@
                     "name": null,
                     "ofType": {
                       "kind": "OBJECT",
-                      "name": "CartDiscount",
+                      "name": "Reference",
                       "ofType": null
                     }
                   }
@@ -32766,18 +37242,6 @@
               "deprecationReason": null
             },
             {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "customFieldList",
               "description": "Custom fields are returned as a list instead of an object structure.",
               "args": [
@@ -32852,7 +37316,7 @@
           "description": null,
           "fields": [
             {
-              "name": "discountCode",
+              "name": "discountCodeRef",
               "description": null,
               "args": [],
               "type": {
@@ -32874,6 +37338,18 @@
               "type": {
                 "kind": "ENUM",
                 "name": "DiscountCodeState",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discountCode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "DiscountCode",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -33025,13 +37501,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "CartDiscount",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "CartDiscount",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -33190,22 +37662,6 @@
               "deprecationReason": null
             },
             {
-              "name": "discount",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Reference",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": true,
-              "deprecationReason": "Will be removed due to naming inconsistencies. Please use 'discountRef'."
-            },
-            {
               "name": "discountRef",
               "description": null,
               "args": [],
@@ -33222,8 +37678,20 @@
               "deprecationReason": null
             },
             {
+              "name": "discount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProductDiscount",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "discountRel",
-              "description": "Temporal. Will be renamed some time in the future",
+              "description": "Temporal. Will be renamed some time in the future. Please use 'discount'.",
               "args": [],
               "type": {
                 "kind": "OBJECT",
@@ -33231,7 +37699,50 @@
                 "ofType": null
               },
               "isDeprecated": true,
-              "deprecationReason": "Will be removed in the future."
+              "deprecationReason": "Will be removed in the future. Please use 'discount'."
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ExternalOAuth",
+          "description": null,
+          "fields": [
+            {
+              "name": "url",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "authorizationHeader",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -33298,7 +37809,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -33524,21 +38035,501 @@
         },
         {
           "kind": "OBJECT",
-          "name": "Initiator",
+          "name": "InStore",
           "description": null,
           "fields": [
             {
-              "name": "clientId",
-              "description": null,
+              "name": "me",
+              "description": "This field can only be used with an access token created with the password flow or with an anonymous session.\n\nIt gives access to the data that is specific to the customer or the anonymous session linked to the access token.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
                 "name": null,
                 "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
+                  "kind": "OBJECT",
+                  "name": "InStoreMe",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cart",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "carts",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CartQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerActiveCart",
+              "description": null,
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "CartQueryInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "CustomerActiveCartInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "OrderQueryInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "MeFieldInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InStoreMe",
+          "description": null,
+          "fields": [
+            {
+              "name": "cart",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "carts",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CartQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activeCart",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "MeQueryInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Initiator",
+          "description": null,
+          "fields": [
+            {
+              "name": "isPlatformClient",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -33587,6 +38578,193 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "clientId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InterfaceInteractionsRaw",
+          "description": null,
+          "fields": [
+            {
+              "name": "typeRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Reference",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TypeDefinition",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeNames",
+                  "description": "The names of the custom fields to include.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "excludeNames",
+                  "description": "The names of the custom fields to exclude.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "RawCustomField",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "InterfaceInteractionsRawResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "limit",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "offset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "results",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "InterfaceInteractionsRaw",
+                      "ofType": null
+                    }
+                  }
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -33744,6 +38922,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "id",
               "description": null,
               "args": [],
@@ -33826,18 +39016,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Initiator",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34160,13 +39338,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "State",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "State",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -34181,6 +39355,59 @@
           "kind": "SCALAR",
           "name": "Json",
           "description": "Raw JSON value",
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "KeyReference",
+          "description": null,
+          "fields": [
+            {
+              "name": "typeId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "KeyReferenceInput",
+          "description": "A key that references a resource.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
@@ -34230,7 +39457,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -34295,7 +39522,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -34359,13 +39586,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductVariant",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "ProductVariant",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -34551,22 +39774,6 @@
               "deprecationReason": null
             },
             {
-              "name": "lineItemMode",
-              "description": null,
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "ENUM",
-                  "name": "LineItemMode",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "customFieldsRaw",
               "description": "This field contains non-typed data. Consider using `customFields` as a typed alternative.",
               "args": [
@@ -34624,6 +39831,18 @@
               "deprecationReason": null
             },
             {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "shippingDetails",
               "description": null,
               "args": [],
@@ -34642,18 +39861,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ItemShippingDetails",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "customFields",
-              "description": "Custom fields",
-              "args": [],
-              "type": {
-                "kind": "INTERFACE",
-                "name": "Type",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -34720,29 +39927,6 @@
           "inputFields": null,
           "interfaces": [],
           "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "ENUM",
-          "name": "LineItemMode",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": [
-            {
-              "name": "GiftLineItem",
-              "description": "The line item was added automatically, because a discount has added a free gift to the cart.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "Standard",
-              "description": "The line item was added during cart creation or with the update action addLineItem. Its quantity can be changed without restrictions.",
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
           "possibleTypes": null
         },
         {
@@ -34923,6 +40107,33 @@
               "deprecationReason": null
             },
             {
+              "name": "cart",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "carts",
               "description": null,
               "args": [
@@ -35000,6 +40211,159 @@
               "deprecationReason": null
             },
             {
+              "name": "order",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "MeQueryInterface",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "MeFieldInterface",
+          "description": "The me field gives access to the data that is specific to the customer or anonymous session linked to the access token.",
+          "fields": [
+            {
+              "name": "me",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "INTERFACE",
+                  "name": "MeQueryInterface",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "InStore",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Query",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "MeQueryInterface",
+          "description": null,
+          "fields": [
+            {
               "name": "cart",
               "description": null,
               "args": [
@@ -35025,12 +40389,198 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "carts",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "CartQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "activeCart",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": null,
           "enumValues": null,
-          "possibleTypes": null
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "InStoreMe",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Me",
+              "ofType": null
+            }
+          ]
         },
         {
           "kind": "OBJECT",
@@ -35150,6 +40700,1083 @@
             }
           ],
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "Order",
+          "description": "An order can be created from a cart, usually after a checkout process has been completed.\n[documentation](https://docs.commercetools.com/http-api-projects-orders.html)",
+          "fields": [
+            {
+              "name": "customerId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerEmail",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anonymousId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lineItems",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "LineItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customLineItems",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CustomLineItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalPrice",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxedPrice",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TaxedPrice",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingAddress",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Address",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "billingAddress",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Address",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inventoryMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "InventoryMode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TaxMode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxRoundingMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "RoundingMode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "taxCalculationMode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TaxCalculationMode",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerGroup",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "CustomerGroup",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerGroupRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "country",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Country",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ShippingInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "discountCodes",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "DiscountCodeInfo",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "refusedGifts",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "CartDiscount",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "refusedGiftsRefs",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Reference",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PaymentInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locale",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Locale",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shippingRateInput",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "ShippingRateInput",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "origin",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "CartOrigin",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "storeRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "KeyReference",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "store",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "itemShippingAddresses",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Address",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "completedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orderState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "OrderState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stateRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "State",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "ShipmentState",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "PaymentState",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syncInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "SyncInfo",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "returnInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "ReturnInfo",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastMessageSequenceNumber",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cartRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "cart",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFieldsRaw",
+              "description": "This field contains non-typed data. Consider using `customFields` as a typed alternative.",
+              "args": [
+                {
+                  "name": "includeNames",
+                  "description": "The names of the custom fields to include.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "excludeNames",
+                  "description": "The names of the custom fields to exclude.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RawCustomField",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFieldList",
+              "description": "Custom fields are returned as a list instead of an object structure.",
+              "args": [
+                {
+                  "name": "includeNames",
+                  "description": "The names of the custom fields to include.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all attributes are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "excludeNames",
+                  "description": "The names of the custom fields to exclude.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all attributes are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "CustomField",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Versioned",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "OrderQueryInterface",
+          "description": "Fields to access orders. Includes direct access to a single order and searching for orders.",
+          "fields": [
+            {
+              "name": "order",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "InStore",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Query",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "OrderQueryResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "offset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "results",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Order",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "OrderState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Confirmed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Cancelled",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Complete",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Open",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -35304,9 +41931,481 @@
         },
         {
           "kind": "OBJECT",
+          "name": "Payment",
+          "description": "Payments hold information about the current state of receiving and/or refunding money.\n[documentation](https://docs.commercetools.com/http-api-projects-payments)",
+          "fields": [
+            {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customerRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customer",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Customer",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "anonymousId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaceId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amountPlanned",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amountAuthorized",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "https://docs.commercetools.com/release-notes.html#releases-2017-09-29-payment-api-beta-changes"
+            },
+            {
+              "name": "authorizedUntil",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "https://docs.commercetools.com/release-notes.html#releases-2017-09-29-payment-api-beta-changes"
+            },
+            {
+              "name": "amountPaid",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "https://docs.commercetools.com/release-notes.html#releases-2017-09-29-payment-api-beta-changes"
+            },
+            {
+              "name": "amountRefunded",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Money",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "https://docs.commercetools.com/release-notes.html#releases-2017-09-29-payment-api-beta-changes"
+            },
+            {
+              "name": "paymentMethodInfo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentMethodInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentStatus",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentStatus",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "transactions",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Transaction",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaceInteractionsRaw",
+              "description": null,
+              "args": [
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "InterfaceInteractionsRawResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFieldsRaw",
+              "description": "This field contains non-typed data. Consider using `customFields` as a typed alternative.",
+              "args": [
+                {
+                  "name": "includeNames",
+                  "description": "The names of the custom fields to include.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "excludeNames",
+                  "description": "The names of the custom fields to exclude.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all custom fields are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "RawCustomField",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFields",
+              "description": "This field would contain type data",
+              "args": [],
+              "type": {
+                "kind": "INTERFACE",
+                "name": "Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "customFieldList",
+              "description": "Custom fields are returned as a list instead of an object structure.",
+              "args": [
+                {
+                  "name": "includeNames",
+                  "description": "The names of the custom fields to include.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all attributes are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "excludeNames",
+                  "description": "The names of the custom fields to exclude.\n\nIf neither `includeNames` nor `excludeNames` are provided, then all attributes are returned.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INTERFACE",
+                    "name": "CustomField",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Versioned",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "PaymentInfo",
           "description": null,
           "fields": [
+            {
+              "name": "payments",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Payment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
             {
               "name": "paymentRefs",
               "description": null,
@@ -35327,6 +42426,285 @@
                     }
                   }
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PaymentMethodInfo",
+          "description": null,
+          "fields": [
+            {
+              "name": "paymentInterface",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "method",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+                {
+                  "name": "locale",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Locale",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "acceptLanguage",
+                  "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Locale",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nameAllLocales",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LocalizedString",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PaymentQueryResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "offset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "results",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Payment",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "PaymentState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Paid",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CreditOwed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Failed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BalanceDue",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "PaymentStatus",
+          "description": null,
+          "fields": [
+            {
+              "name": "interfaceCode",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaceText",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "stateRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Reference",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "State",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -35454,8 +42832,8 @@
                 "name": "ProductCatalogData",
                 "ofType": null
               },
-              "isDeprecated": false,
-              "deprecationReason": null
+              "isDeprecated": true,
+              "deprecationReason": "only 'masterData' supported"
             },
             {
               "name": "skus",
@@ -35607,13 +42985,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductData",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "ProductData",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -35623,13 +42997,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "ProductData",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "ProductData",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -35683,7 +43053,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -35724,7 +43094,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -35809,7 +43179,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -35949,7 +43319,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -36008,7 +43378,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -36049,7 +43419,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -36090,7 +43460,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -36145,6 +43515,24 @@
               "name": "variants",
               "description": null,
               "args": [
+                {
+                  "name": "skus",
+                  "description": "Queries for products with specified SKUs",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "isOnStock",
                   "description": null,
@@ -36208,6 +43596,24 @@
               "name": "allVariants",
               "description": null,
               "args": [
+                {
+                  "name": "skus",
+                  "description": "Queries for products with specified SKUs",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
                 {
                   "name": "isOnStock",
                   "description": null,
@@ -36424,12 +43830,24 @@
               "deprecationReason": null
             },
             {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": null,
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -36470,7 +43888,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -36975,7 +44393,7 @@
             },
             {
               "name": "customFields",
-              "description": "Custom fields",
+              "description": "This field would contain type data",
               "args": [],
               "type": {
                 "kind": "INTERFACE",
@@ -38018,13 +45436,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Channel",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Channel",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -38253,6 +45667,18 @@
               "deprecationReason": null
             },
             {
+              "name": "externalOAuth",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ExternalOAuth",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "messages",
               "description": null,
               "args": [],
@@ -38344,12 +45770,86 @@
               "description": "This field can only be used with an access token created with the password flow or with an anonymous session.\n\nIt gives access to the data that is specific to the customer or the anonymous session linked to the access token.",
               "args": [],
               "type": {
-                "kind": "OBJECT",
-                "name": "Me",
-                "ofType": null
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Me",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "inStore",
+              "description": "This field gives access to the resources (such as carts) that are inside the given store.",
+              "args": [
+                {
+                  "name": "key",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "KeyReferenceInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "InStore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "inStores",
+              "description": "This field gives access to the resources (such as carts) that are inside one of the given stores.",
+              "args": [
+                {
+                  "name": "keys",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "SCALAR",
+                          "name": "KeyReferenceInput",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "InStore",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
             },
             {
               "name": "customerGroup",
@@ -38357,7 +45857,7 @@
               "args": [
                 {
                   "name": "id",
-                  "description": "Queries for a customer group with specified ID",
+                  "description": "Queries with specified ID",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -38367,7 +45867,7 @@
                 },
                 {
                   "name": "key",
-                  "description": "Queries for a customer group with specified [customer group key](https://dev.commercetools.com/http-api-projects-customerGroups.html#key)",
+                  "description": "Queries with specified key",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -38455,7 +45955,7 @@
               "args": [
                 {
                   "name": "id",
-                  "description": "Queries for a category with specified ID",
+                  "description": "Queries with specified ID",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -38465,7 +45965,7 @@
                 },
                 {
                   "name": "key",
-                  "description": "Queries for a category with specified [category key](https://dev.commercetools.com/http-api-projects-categories.html#key)",
+                  "description": "Queries with specified key",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -38553,7 +46053,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "NON_NULL",
                     "name": null,
@@ -38601,7 +46101,7 @@
                 },
                 {
                   "name": "filters",
-                  "description": "Filters to apply during the autocomplete - supported fields are:\n* `id`\n* `slug`\n* `externalId`\n* `ancestors`\n* `parent.id`\n* `level`\n* `createdAt`\n* `modifiedAt`\n* `name.{language}:missing`\n* `externalId:missing`\n* `description.{language}:missing`\n* `childCount`\n* `productCount`\n* `productTypeNames`",
+                  "description": "Filters to apply during the search and autocomplete - supported fields are:\n* `id`\n* `slug`\n* `externalId`\n* `key`\n* `ancestors`\n* `parent.id`\n* `level`\n* `createdAt`\n* `modifiedAt`\n* `name.{language}:missing`\n* `externalId:missing`\n* `description.{language}:missing`\n* `childCount`\n* `productCount`\n* `productTypeNames`",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -38694,7 +46194,7 @@
                 },
                 {
                   "name": "filters",
-                  "description": "Filters to apply during the autocomplete - supported fields are:\n* `id`\n* `slug`\n* `externalId`\n* `ancestors`\n* `parent.id`\n* `level`\n* `createdAt`\n* `modifiedAt`\n* `name.{language}:missing`\n* `externalId:missing`\n* `description.{language}:missing`\n* `childCount`\n* `productCount`\n* `productTypeNames`",
+                  "description": "Filters to apply during the search and autocomplete - supported fields are:\n* `id`\n* `slug`\n* `externalId`\n* `key`\n* `ancestors`\n* `parent.id`\n* `level`\n* `createdAt`\n* `modifiedAt`\n* `name.{language}:missing`\n* `externalId:missing`\n* `description.{language}:missing`\n* `childCount`\n* `productCount`\n* `productTypeNames`",
                   "type": {
                     "kind": "LIST",
                     "name": null,
@@ -38757,15 +46257,21 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "Queries with specified ID",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -38947,15 +46453,21 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "Queries with specified ID",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -39039,15 +46551,21 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "Queries with specified ID",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -39229,15 +46747,21 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "Queries with specified ID",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -39321,15 +46845,21 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "Queries with specified ID",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -39505,15 +47035,21 @@
               "args": [
                 {
                   "name": "id",
-                  "description": null,
+                  "description": "Queries with specified ID",
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null
                 }
@@ -39688,26 +47224,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries for a product with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries for a product with specified [product key](https://dev.commercetools.com/http-api-projects-products.html#key)",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "sku",
                   "description": "Queries for a product with specified SKU",
                   "type": {
@@ -39720,6 +47236,26 @@
                 {
                   "name": "variantKey",
                   "description": "Queries for a product with specified [product variant key](https://dev.commercetools.com/http-api-projects-products.html#variant_key)",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -39922,26 +47458,6 @@
               "description": null,
               "args": [
                 {
-                  "name": "id",
-                  "description": "Queries a customer with specified ID",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "key",
-                  "description": "Queries a customer with specified key",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
                   "name": "emailToken",
                   "description": "Queries a customer with specified email token",
                   "type": {
@@ -39954,6 +47470,26 @@
                 {
                   "name": "passwordToken",
                   "description": "Queries a customer with specified password token",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
                   "type": {
                     "kind": "SCALAR",
                     "name": "String",
@@ -40155,33 +47691,6 @@
               "deprecationReason": null
             },
             {
-              "name": "customerActiveCart",
-              "description": null,
-              "args": [
-                {
-                  "name": "customerId",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Cart",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "carts",
               "description": null,
               "args": [
@@ -40247,6 +47756,229 @@
               "deprecationReason": null
             },
             {
+              "name": "customerActiveCart",
+              "description": null,
+              "args": [
+                {
+                  "name": "customerId",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Cart",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "order",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "orderNumber",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Order",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "orders",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "OrderQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payment",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Payment",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payments",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PaymentQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "project",
               "description": null,
               "args": [],
@@ -40261,10 +47993,221 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "store",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": "Queries with specified ID",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "key",
+                  "description": "Queries with specified key",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Store",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "stores",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "StoreQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "beta feature"
+            },
+            {
+              "name": "apiClient",
+              "description": null,
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "APIClientWithoutSecret",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "apiClients",
+              "description": null,
+              "args": [
+                {
+                  "name": "where",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "sort",
+                  "description": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "String",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "limit",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "offset",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "APIClientWithoutSecretQueryResult",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
-          "interfaces": [],
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "CartQueryInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "CustomerActiveCartInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "OrderQueryInterface",
+              "ofType": null
+            },
+            {
+              "kind": "INTERFACE",
+              "name": "MeFieldInterface",
+              "ofType": null
+            }
+          ],
           "enumValues": null,
           "possibleTypes": null
         },
@@ -40410,6 +48353,281 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ReturnInfo",
+          "description": "Stores information about returns connected to this order.",
+          "fields": [
+            {
+              "name": "items",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INTERFACE",
+                      "name": "ReturnItem",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "returnTrackingId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "returnDate",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "ReturnItem",
+          "description": null,
+          "fields": [
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "quantity",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "comment",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "shipmentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnShipmentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "paymentState",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "ReturnPaymentState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "CustomLineItemReturnItem",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "LineItemReturnItem",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "ENUM",
+          "name": "ReturnPaymentState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "NotRefunded",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Refunded",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Initial",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NonRefundable",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ReturnShipmentState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Unusable",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "BackInStock",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Returned",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Advised",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "ENUM",
           "name": "RoundingMode",
           "description": null,
@@ -40534,6 +48752,53 @@
           "inputFields": null,
           "interfaces": null,
           "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "ShipmentState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Delayed",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Backorder",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Partial",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Ready",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Shipped",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
           "possibleTypes": null
         },
         {
@@ -41351,7 +49616,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -41412,7 +49677,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -41756,6 +50021,271 @@
         },
         {
           "kind": "OBJECT",
+          "name": "Store",
+          "description": "[BETA] Stores allow defining different contexts for a project.",
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "version",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [
+                {
+                  "name": "locale",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Locale",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "acceptLanguage",
+                  "description": "List of languages the client is able to understand, and which locale variant is preferred.",
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Locale",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nameAllLocales",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "LocalizedString",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createdBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "lastModifiedBy",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Initiator",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "Versioned",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "StoreQueryResult",
+          "description": null,
+          "fields": [
+            {
+              "name": "offset",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "count",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "total",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Long",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "results",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "Store",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
           "name": "SubRate",
           "description": null,
           "fields": [
@@ -41785,6 +50315,73 @@
                 "ofType": {
                   "kind": "SCALAR",
                   "name": "Float",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "SyncInfo",
+          "description": "Stores information about order synchronization activities (like export or import).",
+          "fields": [
+            {
+              "name": "channelRef",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Reference",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "channel",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Channel",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "externalId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "syncedAt",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
                   "ofType": null
                 }
               },
@@ -42398,19 +50995,19 @@
         {
           "kind": "ENUM",
           "name": "TextInputHint",
-          "description": null,
+          "description": "UI hint telling what kind of edit control should be displayed for a text attribute.",
           "fields": null,
           "inputFields": null,
           "interfaces": null,
           "enumValues": [
             {
-              "name": "SingleLine",
+              "name": "MultiLine",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
             },
             {
-              "name": "MultiLine",
+              "name": "SingleLine",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -42494,6 +51091,177 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "Transaction",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "timestamp",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "TransactionType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "amount",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Money",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interactionId",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "state",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "TransactionState",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "TransactionState",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Failure",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Success",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Pending",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Initial",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "TransactionType",
+          "description": null,
+          "fields": null,
+          "inputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "Chargeback",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Refund",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Charge",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "CancelAuthorization",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "Authorization",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
           "kind": "INTERFACE",
           "name": "Type",
           "description": null,
@@ -42519,13 +51287,9 @@
               "description": null,
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "TypeDefinition",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "TypeDefinition",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -42569,7 +51333,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -42610,7 +51374,7 @@
               "args": [
                 {
                   "name": "locale",
-                  "description": "String is define for different locales. This argument specifies the desired locale.",
+                  "description": "String is defined for different locales. This argument specifies the desired locale.",
                   "type": {
                     "kind": "SCALAR",
                     "name": "Locale",
@@ -43057,6 +51821,11 @@
           "possibleTypes": [
             {
               "kind": "OBJECT",
+              "name": "Cart",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "CartDiscount",
               "ofType": null
             },
@@ -43092,6 +51861,16 @@
             },
             {
               "kind": "OBJECT",
+              "name": "Order",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Payment",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
               "name": "Product",
               "ofType": null
             },
@@ -43113,6 +51892,11 @@
             {
               "kind": "OBJECT",
               "name": "State",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "Store",
               "ofType": null
             },
             {
@@ -43191,6 +51975,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "key",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/package-lock.json
+++ b/package-lock.json
@@ -5513,6 +5513,14 @@
       "requires": {
         "node-fetch": "2.1.2",
         "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+          "dev": true
+        }
       }
     },
     "cross-spawn": {
@@ -17919,10 +17927,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "vue-product-zoomer": "^2.0.11",
     "vue-router": "^3.0.3",
     "vuelidate": "^0.7.4",
-    "vuex": "^3.0.1"
+    "vuex": "^3.0.1",
+    "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^4.0.2",

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,6 @@
+// Required until Cypress supports fetch API
+// https://github.com/cypress-io/cypress/issues/95
+import 'whatwg-fetch';
 import Vue from 'vue';
 import Vuelidate from 'vuelidate';
 import ProductZoomer from 'vue-product-zoomer';

--- a/tests/e2e/specs/cartDetailPage_spec.js
+++ b/tests/e2e/specs/cartDetailPage_spec.js
@@ -55,34 +55,60 @@ describe('CartDetailPage', () => {
     cy.addLineItem('/product/lemare-booties-0778-grey/M0E20000000E0WX', 3);
     cy.visit('/cart');
 
-    cy.get('[data-test=cart-line-item-quantity]')
-      .should('have.value', '3')
-      .clear()
-      .type('5');
-    cy.get('[data-test=cart-line-item-total-price]')
-      .contains(/^\s*870,60\s€\s*$/);
+    cy.get('[data-test=cart-line-item]')
+      .should('have.length', 1)
+      .then(($lineItem) => {
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-quantity]')
+          .should('have.value', '3')
+          .clear()
+          .type('5');
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-total-price]')
+          .contains(/^\s*870,60\s€\s*$/);
 
-    cy.get('[data-test=cart-line-item-quantity-inc]')
-      .click()
-      .click();
-    cy.get('[data-test=cart-line-item-quantity]')
-      .should('have.value', '7');
-    cy.get('[data-test=cart-line-item-total-price]')
-      .contains(/^\s*1.218,84\s€\s*$/);
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-quantity-inc]')
+          .click()
+          .click();
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-quantity]')
+          .should('have.value', '7');
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-total-price]')
+          .contains(/^\s*1.218,84\s€\s*$/);
 
-    cy.get('[data-test=cart-line-item-quantity-dec]')
-      .click();
-    cy.get('[data-test=cart-line-item-quantity]')
-      .should('have.value', '6');
-    cy.get('[data-test=cart-line-item-total-price]')
-      .contains(/^\s*1.044,72\s€\s*$/);
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-quantity-dec]')
+          .click();
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-quantity]')
+          .should('have.value', '6');
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-total-price]')
+          .contains(/^\s*1.044,72\s€\s*$/);
 
-
-    cy.get('[data-test=cart-line-item-delete]').click();
+        cy.wrap($lineItem)
+          .find('[data-test=cart-line-item-delete]').click();
+      });
     cy.get('[data-test=cart-line-item]').should('have.length', 0);
   });
 
+  const cartDiscount = {
+    value: {
+      relative: { permyriad: 5000 },
+    },
+    cartPredicate: '1=1',
+    sortOrder: Math.random().toString(),
+    name: { locale: 'en', value: '50% discount' },
+    requiresDiscountCode: true,
+    target: {
+      lineItems: { predicate: '1=1' },
+    },
+  };
+
   it('applies and deletes discount codes', () => {
+    cy.addDiscountCode(cartDiscount, 'SUNRISE_CI');
     cy.addLineItem('/product/lemare-booties-0778-brown/M0E20000000E0XM', 1);
     cy.visit('/cart');
 
@@ -90,18 +116,18 @@ describe('CartDetailPage', () => {
       .contains(/^\s*248,75\s€\s*$/);
 
     cy.get('[data-test=discount-code-input]')
-      .type('CODE2019');
+      .type('SUNRISE_CI');
     cy.get('[data-test=apply-discount-code-button]')
       .click();
     cy.get('[data-test=cart-total-price]')
-      .contains(/^\s*236,31\s€\s*$/);
+      .contains(/^\s*124,37\s€\s*$/);
 
     cy.get('[data-test=discount-code-name]')
-      .contains('CODE2019');
+      .contains('SUNRISE_CI');
     cy.get('[data-test=remove-discount-button]')
       .click();
 
     cy.get('[data-test=cart-line-item-total-price]')
-      .contains(/^\s*248,75\s€\s*$/);
+      .contains(/^\s*124,37\s€\s*$/);
   });
 });

--- a/tests/e2e/specs/orderDetail_spec.js
+++ b/tests/e2e/specs/orderDetail_spec.js
@@ -1,5 +1,18 @@
 describe('OrderDetailPage', () => {
-  const customer = {
+  const cartDiscount = {
+    value: {
+      relative: { permyriad: 5000 },
+    },
+    cartPredicate: '1=1',
+    sortOrder: Math.random().toString(),
+    name: { locale: 'en', value: '50% discount' },
+    requiresDiscountCode: true,
+    target: {
+      lineItems: { predicate: '1=1' },
+    },
+  };
+
+  const customerDraft = {
     firstName: 'Charlie',
     lastName: 'Bucket',
     email: 'charlie.bucket+ci@commercetools.com',
@@ -43,7 +56,7 @@ describe('OrderDetailPage', () => {
       email: 'charlie.bucket+ci@commercetools.com',
     },
     shippingMethod: {
-      id: 'fe39f916-d4d7-4f99-9554-5949efeb2a0c',
+      key: 'express-EU',
     },
     lineItems: [{
       sku: 'M0E20000000EFWN',
@@ -53,12 +66,13 @@ describe('OrderDetailPage', () => {
       quantity: 2,
     },
     ],
-    discountCodes: ['CODE2019'],
+    discountCodes: ['SUNRISE_CI'],
   };
 
   before(() => {
-    cy.login(customer);
-    cy.createMyOrder(cartDraft, orderDraft);
+    cy.addDiscountCode(cartDiscount, 'SUNRISE_CI');
+    cy.login(customerDraft);
+    cy.createOrder(cartDraft, orderDraft);
   });
 
   it('shows order details', () => {
@@ -71,9 +85,13 @@ describe('OrderDetailPage', () => {
     cy.get('[data-test=details-order-date]')
       .contains(/^\s*\d{1,2}\.*\s*[A-Za-zäÄöÖüÜß].+\s*\d{4}\s*$/);
     cy.get('[data-test=cart-subtotal-price]')
-      .contains(/^\s*349,21\s€\s*$/);
+      .contains(/^\s*183,80\s€\s*$/);
+    // cy.get('[data-test=cart-shipping-price]')
+    //   .contains(/^\s*10,00\s€\s*$/);
+    // cy.get('[data-test=cart-taxes-amount]')
+    //   .contains(/^\s*30,95\s€\s*$/);
     cy.get('[data-test=cart-total-price]')
-      .contains(/^\s*349,21\s€\s*$/);
+      .contains(/^\s*193,80\s€\s*$/);
     cy.get('[data-test=order-line-items]')
       .should('have.length', 2)
       .eq(1)
@@ -86,7 +104,7 @@ describe('OrderDetailPage', () => {
           .contains(/^\s*139,30\s€\s*$/);
       });
     cy.get('[data-test=discount-code-name]')
-      .contains('CODE2019');
+      .contains('SUNRISE_CI');
     cy.get('[data-test=remove-discount-button]')
       .should('not.exist');
   });

--- a/tests/e2e/specs/orderList_spec.js
+++ b/tests/e2e/specs/orderList_spec.js
@@ -44,8 +44,8 @@ describe('my orders', () => {
   });
 
   it('shows my orders', () => {
-    cy.createMyOrder(cartDraft1, orderDraft1);
-    cy.createMyOrder(cartDraft2, orderDraft2);
+    cy.createOrder(cartDraft1, orderDraft1);
+    cy.createOrder(cartDraft2, orderDraft2);
     cy.get('[data-test=my-orders-button]').click();
     cy.get('[data-test=order-list]')
       .should('have.length', 2)

--- a/tests/e2e/specs/pageProductOverview_spec.js
+++ b/tests/e2e/specs/pageProductOverview_spec.js
@@ -2,6 +2,7 @@ describe('Product overview page', () => {
   before(() => {
     cy.visit('/products/men');
   });
+
   it('Changes sorting settings', () => {
     cy.get('span[data-test=sort-selector]')
       .click()
@@ -41,6 +42,7 @@ describe('Product overview page', () => {
       .find('[data-test=product-thumbnail-name]')
       .contains('Shirt ”David” MU light blue');
   });
+
   it('Applies sorting settings from URL', () => {
     cy.visit('/products/men?sort=newest');
     cy.get('[data-test=product-list]', { timeout: 20000 })

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -24,8 +24,9 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-import gql from 'graphql-tag';
 import createClient from './test-apollo';
+import * as query from './queries';
+import * as mutation from './mutations';
 
 const clientPromise = createClient();
 
@@ -37,55 +38,12 @@ Cypress.Commands.add('login', customer => cy.createCustomer(customer).then(() =>
   cy.get('[data-test=login-form-submit]').click();
 }));
 
-Cypress.Commands.add('createCustomer', (draft) => {
-  const createCustomer = client => client.mutate({
-    mutation: gql`
-        mutation createNewCustomer($draft: CustomerSignMeUpDraft!) {
-          customerSignMeUp(draft: $draft) {
-            customer {
-              id
-            }
-          }
-        }`,
-    variables: { draft },
-  });
+Cypress.Commands.add('createCustomer', draft => cy.wrap(clientPromise
+  .then(client => mutation.deleteCustomer(client, draft.email)
+    .then(() => mutation.createCustomer(client, draft)))));
 
-  return cy.deleteCustomer(draft).then(() => cy.wrap(clientPromise.then(client => createCustomer(client))));
-});
-
-Cypress.Commands.add('deleteCustomer', ({ email }) => {
-  const deleteCustomer = client => client.query({
-    query: gql`
-      query queryCustomerByEmail($predicate: String) {
-        customers(limit: 1, where: $predicate) {
-          results {
-            id
-            version
-          }
-        }
-      }`,
-    variables: { predicate: `email = "${email}"` },
-    fetchPolicy: 'network-only',
-  }).then(async (response) => {
-    const customer = response.data.customers.results[0];
-    if (customer) {
-      await client.mutate({
-        mutation: gql`
-            mutation deleteOldCustomer($id: String!, $version: Long!) {
-              deleteCustomer(id: $id, version: $version, personalDataErasure: true) {
-                id
-              }
-            }`,
-        variables: {
-          id: customer.id,
-          version: customer.version,
-        },
-      }).catch(e => console.warn('Customer might have been already deleted', e));
-    }
-  });
-
-  return cy.wrap(clientPromise.then(client => deleteCustomer(client)));
-});
+Cypress.Commands.add('deleteCustomer', ({ email }) => cy.wrap(clientPromise
+  .then(client => mutation.deleteCustomer(client, email))));
 
 Cypress.Commands.add('addLineItem', (url, quantity) => {
   cy.visit(url);
@@ -98,81 +56,17 @@ Cypress.Commands.add('addLineItem', (url, quantity) => {
   cy.get('[data-test=mini-cart-content]').should('be.visible');
 });
 
-Cypress.Commands.add('createMyOrder', (cartDraft, orderDraft) => {
-  const createNewOrder = client => client.query({
-    query: gql`
-      query queryCustomerByEmail($predicate: String) {
-        customers(limit: 1, where: $predicate) {
-          results {
-            id
-            version
-          }
-        }
-      }`,
-    variables: { predicate: `email = "${cartDraft.customerEmail}"` },
-    fetchPolicy: 'network-only',
-  }).then((response) => {
-    const customer = response.data.customers.results[0];
-    const draft = Object.assign({}, cartDraft, { customerId: customer.id });
-    return client.mutate({
-      mutation: gql`
-      mutation createMyCart($draft: CartDraft!){
-      createCart (draft: $draft) {
-        id, version
-      }
-  }`,
-      variables: {
-        draft,
-      },
-    });
-  }).then((response) => {
-    const cart = response.data.createCart;
-    const draft = Object.assign({}, orderDraft, { id: cart.id, version: cart.version });
-    client.mutate({
-      mutation: gql`
-          mutation createOrder($draft: OrderCartCommand!){
-            createOrderFromCart(draft: $draft) {
-              id
-            }
-          }`,
-      variables: {
-        draft,
-      },
-    });
-  });
-  return cy.deleteOrder(orderDraft).then(() => cy.wrap(clientPromise.then(client => createNewOrder(client))));
-});
+Cypress.Commands.add('addDiscountCode', (cartDiscountDraft, code) => cy.wrap(clientPromise
+  .then(client => mutation.deleteDiscountCode(client, code)
+    .then(() => mutation.createDiscountCode(client, cartDiscountDraft, code)))));
 
-Cypress.Commands.add('deleteOrder', ({ orderNumber }) => {
-  const deleteOrder = client => client.query({
-    query: gql`
-      query queryOrderByNumber($predicate: String) {
-        orders(limit: 1, where: $predicate) {
-          results {
-            version,
-            id
-          }
-        }
-      }`,
-    variables: { predicate: `orderNumber = "${orderNumber}"` },
-    fetchPolicy: 'network-only',
-  }).then(async (response) => {
-    const order = response.data.orders.results[0];
-    if (order) {
-      await client.mutate({
-        mutation: gql`
-            mutation deleteOldOrder($id: String!, $version: Long!) {
-              deleteOrder(id: $id, version: $version) {
-                id
-              }
-            }`,
-        variables: {
-          id: order.id,
-          version: order.version,
-        },
-      }).catch(e => console.warn('Order might have been already deleted', e));
-    }
-  });
-
-  return cy.wrap(clientPromise.then(client => deleteOrder(client)));
-});
+Cypress.Commands.add('createOrder', (cartDraft, orderDraft) => cy.wrap(clientPromise
+  .then(client => mutation.deleteOrder(client, orderDraft.orderNumber)
+    .then(() => query.customerByEmail(client, cartDraft.customerEmail)
+      .then((customer) => {
+        const draft = Object.assign({}, cartDraft, { customerId: customer.id });
+        return mutation.createCart(client, draft);
+      }).then((cart) => {
+        const draft = Object.assign({}, orderDraft, { id: cart.id, version: cart.version });
+        return mutation.createOrder(client, draft);
+      })))));

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -13,8 +13,14 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 
-// Import commands.js using ES2015 syntax:
 import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Required until Cypress supports fetch API
+// https://github.com/cypress-io/cypress/issues/95
+Cypress.on('window:before:load', (win) => {
+  // eslint-disable-next-line no-param-reassign
+  win.fetch = null;
+});

--- a/tests/e2e/support/mutations.js
+++ b/tests/e2e/support/mutations.js
@@ -1,0 +1,148 @@
+import gql from 'graphql-tag';
+import * as query from './queries';
+
+export function createCustomer(client, draft) {
+  return client.mutate({
+    mutation: gql`
+      mutation createNewCustomer($draft: CustomerSignMeUpDraft!) {
+        customerSignMeUp(draft: $draft) {
+          customer {
+            id
+          }
+        }
+      }`,
+    variables: {
+      draft,
+    },
+  }).then(response => response.data.customerSignMeUp.customer);
+}
+
+export function createCart(client, draft) {
+  return client.mutate({
+    mutation: gql`
+      mutation createCart($draft: CartDraft!){
+        createCart (draft: $draft) {
+          id, version
+        }
+      }`,
+    variables: {
+      draft,
+    },
+  }).then(response => response.data.createCart);
+}
+
+export function createOrder(client, draft) {
+  return client.mutate({
+    mutation: gql`
+      mutation createOrder($draft: OrderCartCommand!){
+        createOrderFromCart(draft: $draft) {
+          id
+        }
+      }`,
+    variables: {
+      draft,
+    },
+  }).then(response => response.data.createOrderFromCart);
+}
+
+export function createDiscountCode(client, cartDiscountDraft, code) {
+  return client.mutate({
+    mutation: gql`
+      mutation createNewCartDiscount($draft: CartDiscountDraft!) {
+        createCartDiscount(draft: $draft) {
+          id
+        }
+      }`,
+    variables: {
+      draft: cartDiscountDraft,
+    },
+  })
+    .then(response => response.data.createCartDiscount.id)
+    .then(id => client.mutate({
+      mutation: gql`
+      mutation createNewDiscountCode($id: String!, $code: String!) {
+        createDiscountCode(draft: {
+          code: $code,
+          cartDiscounts: {
+            typeId: "cart-discount",
+            id: $id
+          }
+        }) {
+          id
+        }
+      }`,
+      variables: { code, id },
+    })).then(response => response.data.createDiscountCode);
+}
+
+export function deleteDiscountCode(client, code) {
+  return query.discountCodeByCode(client, code)
+    .then(async (discountCode) => {
+      if (discountCode) {
+        await client.mutate({
+          mutation: gql`
+          mutation deleteDiscountCode($id: String!, $version: Long!) {
+            deleteDiscountCode(id: $id, version: $version) {
+              id
+            }
+          }`,
+          variables: {
+            id: discountCode.id,
+            version: discountCode.version,
+          },
+        }).catch(e => console.warn('Discount code might have already been deleted', e));
+        await discountCode.cartDiscounts.forEach(cartDiscount => client.mutate({
+          mutation: gql`
+          mutation deleteCartDiscount($id: String!, $version: Long!) {
+            deleteCartDiscount(id: $id, version: $version) {
+              id
+            }
+          }`,
+          variables: {
+            id: cartDiscount.id,
+            version: cartDiscount.version,
+          },
+        }).catch(e => console.warn('Cart discount might have already been deleted', e)));
+      }
+    });
+}
+
+export function deleteOrder(client, orderNumber) {
+  return query.orderByNumber(client, orderNumber)
+    .then(async (order) => {
+      if (order) {
+        await client.mutate({
+          mutation: gql`
+          mutation deleteOrder($id: String!, $version: Long!) {
+            deleteOrder(id: $id, version: $version) {
+              id
+            }
+          }`,
+          variables: {
+            id: order.id,
+            version: order.version,
+          },
+        }).catch(e => console.warn('Order might have already been deleted', e));
+      }
+    });
+}
+
+export function deleteCustomer(client, email) {
+  return query.customerByEmail(client, email)
+    .then(async (customer) => {
+      if (customer) {
+        await client.mutate({
+          mutation: gql`
+          mutation deleteCustomer($id: String!, $version: Long!) {
+            deleteCustomer(id: $id, version: $version, personalDataErasure: true) {
+              id
+            }
+          }`,
+          variables: {
+            id: customer.id,
+            version: customer.version,
+          },
+        }).catch(e => console.warn('Customer might have already been deleted', e));
+      }
+    });
+}

--- a/tests/e2e/support/queries.js
+++ b/tests/e2e/support/queries.js
@@ -1,0 +1,53 @@
+import gql from 'graphql-tag';
+
+export function customerByEmail(client, email) {
+  return client.query({
+    query: gql`
+      query queryCustomerByEmail($predicate: String) {
+        customers(limit: 1, where: $predicate) {
+          results {
+            id
+            version
+          }
+        }
+      }`,
+    variables: { predicate: `email = "${email}"` },
+    fetchPolicy: 'network-only',
+  }).then(response => response.data.customers.results[0]);
+}
+
+export function orderByNumber(client, orderNumber) {
+  return client.query({
+    query: gql`
+      query queryOrderByNumber($predicate: String) {
+        orders(limit: 1, where: $predicate) {
+          results {
+            version,
+            id
+          }
+        }
+      }`,
+    variables: { predicate: `orderNumber = "${orderNumber}"` },
+    fetchPolicy: 'network-only',
+  }).then(response => response.data.orders.results[0]);
+}
+
+export function discountCodeByCode(client, code) {
+  return client.query({
+    query: gql`
+      query queryDiscountCodeByCode($predicate: String) {
+        discountCodes(limit: 1, where: $predicate) {
+          results {
+            version,
+            id
+            cartDiscounts {
+              id
+              version
+            }
+          }
+        }
+      }`,
+    variables: { predicate: `code = "${code}"` },
+    fetchPolicy: 'network-only',
+  }).then(response => response.data.discountCodes.results[0]);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12635,6 +12635,11 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"


### PR DESCRIPTION
- Converted requests to XHR on e2e tests, so that Cypress can detect them https://github.com/cypress-io/cypress/issues/95
- Updated GraphQL schema to latest changes
- Create discount codes for the tests instead of expecting them
- Extracted mutations and queries to another file to improve readability in commands
- Remove hardcoded resource IDs
- Fix other issues