### PR TITLE
Extract product route to avoid duplication and reduce complexity

### DIFF
--- a/src/components/common/ProductThumbnail.vue
+++ b/src/components/common/ProductThumbnail.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="col-xs-12 col-sm-6 col-md-4">
-    <router-link :to="{ name: 'product', params: { productSlug, sku } }">
+    <router-link :to="productRoute(currentProduct.slug, matchingVariant.sku)">
       <div data-test="product-thumbnail"
            class="shop-item">
         <div v-if="hasPrice && hasDiscount"
@@ -60,11 +60,11 @@
         </div>
       </div>
       <div class="shop-item-overlay hidden-xs">
-        <button type="button"
-                class="quickview"
-                data-modal="quickview-modal">
-          {{ $t("quickView") }}
-        </button>
+        <!--<button type="button"-->
+                <!--class="quickview"-->
+                <!--data-modal="quickview-modal">-->
+          <!--{{ $t("quickView") }}-->
+        <!--</button>-->
          <!-- <form id="form-add-to-wishlist{{index}}"
                     method="post"
                     {{#if wishlist}}class="hidden"{{/if}}
@@ -119,14 +119,6 @@ export default {
 
     hasImages() {
       return Array.isArray(this.matchingVariant.images) && this.matchingVariant.images.length > 0;
-    },
-
-    productSlug() {
-      return this.currentProduct.slug;
-    },
-
-    sku() {
-      return this.matchingVariant.sku;
     },
   },
 

--- a/src/mixins/productMixin.js
+++ b/src/mixins/productMixin.js
@@ -16,5 +16,12 @@ export default {
       }
       return null;
     },
+
+    productRoute(productSlug, sku) {
+      return {
+        name: 'product',
+        params: { productSlug, sku },
+      };
+    },
   },
 };

--- a/tests/unit/specs/components/common/ProductThumbnail.spec.js
+++ b/tests/unit/specs/components/common/ProductThumbnail.spec.js
@@ -51,20 +51,4 @@ describe('ProductThumbnail.vue', () => {
     wrapper.setProps({ product: { ...options.propsData.product } });
     expect(wrapper.vm.hasImages).toBeFalsy();
   });
-
-  it('obtains the product slug', () => {
-    const slug = { foo: 'bar' };
-    options.propsData.product.masterData.current.slug = slug;
-    const wrapper = shallowMount(ProductThumbnail, options);
-
-    expect(wrapper.vm.productSlug).toEqual(slug);
-  });
-
-  it('obtains the product sku', () => {
-    const sku = { foo: 'bar' };
-    options.propsData.product.masterData.current.masterVariant.sku = sku;
-    const wrapper = shallowMount(ProductThumbnail, options);
-
-    expect(wrapper.vm.sku).toEqual(sku);
-  });
 });


### PR DESCRIPTION
- As title says 🔝 
- Disabled quickview (which we don't need in an SPA).
