### PR TITLE
Remove manifest icons

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,18 +1,6 @@
 {
   "name": "sunrise",
   "short_name": "sunrise",
-  "icons": [
-    {
-      "src": "/img/icons/android-chrome-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/img/icons/android-chrome-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png"
-    }
-  ],
   "start_url": "/index.html",
   "display": "standalone",
   "background_color": "#000000",


### PR DESCRIPTION
They generate some errors in the browser's console because they do not longer exist in the project.
