### PR TITLE
Stop sort selector from sending duplicated routes

### DIFF
--- a/src/components/productoverview/ProductSortSelector.vue
+++ b/src/components/productoverview/ProductSortSelector.vue
@@ -33,12 +33,14 @@ export default {
   methods: {
     changeSortParameter(value) {
       const query = { ...this.$route.query };
-      if (value) {
-        query.sort = value;
-      } else {
-        delete query.sort;
+      if (query.sort !== value) {
+        if (value) {
+          query.sort = value;
+        } else {
+          delete query.sort;
+        }
+        this.$router.replace({ query });
       }
-      this.$router.replace({ query });
     },
   },
 


### PR DESCRIPTION
Make sure the sort selector is not sending duplicated routes, which generates an error (see https://github.com/vuejs/vue-router/issues/2872)

This happened when the user navigates to the POP coming from a different page. Then no sorting is selected, which is exactly the same route we already are in, and the `router.replace` is called.