### PR TITLE
Fix UI after latest chrome update, version 77.0.3865.120

### DIFF
--- a/src/assets/scss/_megamenu.scss
+++ b/src/assets/scss/_megamenu.scss
@@ -265,6 +265,7 @@
 
   .navbar-nav {
     margin: 0;
+    display: flex;
   }
 
   .ui-accordion .ui-accordion-header {

--- a/src/assets/scss/_megamenu.scss
+++ b/src/assets/scss/_megamenu.scss
@@ -260,14 +260,19 @@
     display: none;
   }
 }
+.dropdown-megamenu .navbar-nav {
+  margin: 0;
+  display: flex;
+}
+
+@media screen and (max-width: 768px) {
+  .dropdown-megamenu .navbar-nav {
+    margin: 0;
+    display: block;
+  } 
+}
 
 .dropdown-megamenu {
-
-  .navbar-nav {
-    margin: 0;
-    display: flex;
-  }
-
   .ui-accordion .ui-accordion-header {
     outline: none;
   }

--- a/src/assets/scss/_navigation.scss
+++ b/src/assets/scss/_navigation.scss
@@ -65,14 +65,11 @@
     text-align: center;
     border-right: solid 1px #404953;
 
-  @media screen and (min-width: 768px) {
-    width: inherit;
-    text-align: left;
-  }
     @media screen and (min-width: 768px) {
       width: inherit;
       text-align: left;
     }
+
     > a,
     > button {
       display: -webkit-box;

--- a/src/assets/scss/_navigation.scss
+++ b/src/assets/scss/_navigation.scss
@@ -51,26 +51,25 @@
 
   li {
     color: $white;
-    display: inline-block;
+    display: inline-flex;
     width: 20%;
     height: 50px;
     text-align: center;
     border-right: solid 1px #404953;
 
-    @media screen and (min-width: 768px) {
-      width: inherit;
-      text-align: left;
-    }
-
+  @media screen and (min-width: 768px) {
+    width: inherit;
+    text-align: left;
+  }
+  
     > a,
     > button {
-      display: inline-block;
+      display: -webkit-box;
       text-transform: uppercase;
       letter-spacing: .125rem;
       width: 100%;
       height: 100%;
     }
-
   }
 
   .list-item-nav-toggle {

--- a/src/assets/scss/_navigation.scss
+++ b/src/assets/scss/_navigation.scss
@@ -43,11 +43,19 @@
 
 // All navigation components
 
+@media screen and (max-width: 767px) {
+  .nav-list {
+    li {
+      display: block;
+    }
+  }    
+}
+
 .nav-list {
   margin: 0;
   padding: 0;
   text-transform: uppercase;
-  letter-spacing: .125rem;
+  letter-spacing: .125rem;  
 
   li {
     color: $white;
@@ -204,6 +212,7 @@
 
   .list-item-location {
     float: right;
+    display: inline;
     img {
       height: 20px;
       margin-right: 10px;
@@ -308,6 +317,7 @@
     float: right;
     border: none;
     position: relative;
+    display: block;
 
     @media screen and (min-width: 768px) {
       border-right: solid 1px #404953;
@@ -387,6 +397,7 @@
     }
   }
 }
+
 
 // Sunrise logo and searchbox
 

--- a/src/assets/scss/_navigation.scss
+++ b/src/assets/scss/_navigation.scss
@@ -69,7 +69,10 @@
     width: inherit;
     text-align: left;
   }
-  
+    @media screen and (min-width: 768px) {
+      width: inherit;
+      text-align: left;
+    }
     > a,
     > button {
       display: -webkit-box;


### PR DESCRIPTION
The problem was mostly with display: block! So now the display is with flex.

Header web version: 
<img width="1039" alt="Screen Shot 2019-10-11 at 13 13 24" src="https://user-images.githubusercontent.com/31618523/66647428-2b8d3700-ec29-11e9-9b5a-1d22dbca5ad4.png">

Header mobile version:
<img width="379" alt="Screen Shot 2019-10-11 at 13 13 41" src="https://user-images.githubusercontent.com/31618523/66647448-3ea00700-ec29-11e9-8efe-60295bc1436f.png">

Navigating categories menu without it disappearing:
![2019-10-11 13 11 52](https://user-images.githubusercontent.com/31618523/66647462-4790d880-ec29-11e9-9ee3-033dae382279.gif)
