### PR TITLE
Show translated data

### DIFF
--- a/src/components/productdetail/DetailsSection/template.html
+++ b/src/components/productdetail/DetailsSection/template.html
@@ -1,4 +1,4 @@
-  <div v-if="product"
+  <div v-if="product && attributeTranslation"
        class="row">
     <div class="col-sm-12">
       <div data-test="panel-group-pdp"

--- a/src/components/productdetail/VariantSelector/script.js
+++ b/src/components/productdetail/VariantSelector/script.js
@@ -12,13 +12,19 @@ export default {
   },
   data: () => ({
     product: null,
+    attributeTranslation: null,
   }),
   methods: {
     groupValuesByAttribute(acc, currentItem) {
-      if (!acc[currentItem.name]) {
-        acc[currentItem.name] = [];
+      const key = this.attributeTranslation.get(currentItem.name)
+        || currentItem.name;
+      if (!acc[key]) {
+        acc[key] = {
+          name: currentItem.name,
+          values: [],
+        };
       }
-      acc[currentItem.name].push(currentItem.value || currentItem.label);
+      acc[key].values.push(currentItem.value || currentItem.label);
       return acc;
     },
   },
@@ -93,6 +99,33 @@ export default {
         return {
           locale: this.$i18n.locale,
           sku: this.sku,
+        };
+      },
+    },
+    attributeName: {
+      query: gql`
+        query Translation($locale: Locale!, $type:String!) {
+          productType(key:$type) {
+            attributeDefinitions {
+              results {
+                name
+                label(locale:$locale)
+              }
+            }
+          }
+        }`,
+      manual: true,
+      result({ data, loading }) {
+        if (!loading) {
+          this.attributeTranslation = data.productType.attributeDefinitions.results.reduce(
+            (result, item) => result.set(item.name, item.label), new Map(),
+          );
+        }
+      },
+      variables() {
+        return {
+          locale: this.$i18n.locale,
+          type: 'main',
         };
       },
     },

--- a/src/components/productdetail/VariantSelector/template.html
+++ b/src/components/productdetail/VariantSelector/template.html
@@ -1,17 +1,17 @@
-  <div v-if="product"
+  <div v-if="product && attributeTranslation"
        class="row select-row">
     <ul class="list-inline"
         data-test="variant-selector-list">
-      <li v-for="(values, name) in attributes"
+      <li v-for="(value, name) in attributes"
           :key="name">
         <p class="text-uppercase"
            data-test="attribute-name">
           {{name}}
         </p>
         <AttributeSelect :product="product"
-                         :values="values"
+                         :values="value.values"
                          :sku="sku"
-                         :name="name"
+                         :name="value.name"
                          :selected="selected"
                          :variantCombinations="variantCombinations" />
       </li>

--- a/tests/e2e/specs/productDetailPage_spec.js
+++ b/tests/e2e/specs/productDetailPage_spec.js
@@ -111,7 +111,7 @@ describe('Product detail page', () => {
           .should('have.length', 6)
           .eq(2)
           .should((e) => {
-            expect(e.text()).to.match(/^\s*size:\s+5\s*$/);
+            expect(e.text()).to.match(/^\s*Size:\s+5\s*$/g);
           });
       });
 
@@ -153,5 +153,23 @@ describe('Product detail page', () => {
           .find('[data-test=product-sku]')
           .should('contain', 'sku-36-black');
       });
+  });
+  it('shows correct language', async () => {
+    cy.visit('/product/havaianas-flipflops-brasil-gruen/M0E20000000ELAJ');
+    cy.changeLanguage('Deutsch');
+    cy.get('[data-test=attribute-name]')
+      .should(
+        e => expect(e[1].innerText)
+          .to
+          .include('GRÖSSE'),
+      );
+    cy.get('.accordion-plus').eq(0).click();
+    cy.get('[data-test=product-attributes-list]')
+      .eq(2)
+      .should(
+        (e) => {
+          expect(e[0].innerText).to.include('GRÖSSE');
+        },
+      );
   });
 });


### PR DESCRIPTION
The product detail page shows `color` and `size` and when opening product details the other product attributes do not show their translated value (translated in data from product types).

## Checklist
* [ ] Unit tests
* [ ] E2E tests
* [ ] Documentation
