### PR TITLE
fix missing locale

### DIFF
--- a/src/components/checkout/CartOverview/script.js
+++ b/src/components/checkout/CartOverview/script.js
@@ -44,6 +44,9 @@ export default {
           locale: locale(this),
         };
       },
+      skip() {
+        return !locale(this);
+      },
     },
   },
 };

--- a/src/components/checkout/StepPlaceOrderForm/script.js
+++ b/src/components/checkout/StepPlaceOrderForm/script.js
@@ -59,6 +59,9 @@ export default {
           locale: locale(this),
         };
       },
+      skip() {
+        return !locale(this);
+      },
     },
   },
   validations: {

--- a/src/components/root/script.js
+++ b/src/components/root/script.js
@@ -22,6 +22,11 @@ export default {
       lastLocale: null,
     };
   },
+  computed: {
+    locale() {
+      return loc(this);
+    },
+  },
   beforeCreate() {
     // when the page loads set store locale to what is in the url
     if (this?.$store?.state?.locale !== loc(this)) {

--- a/src/components/root/template.html
+++ b/src/components/root/template.html
@@ -1,4 +1,4 @@
-<div>
+<div v-if="locale">
   <header>
     <router-view name="header"/>
   </header>


### PR DESCRIPTION
Missing locale in url will be forwarded to locale from local storage or defaults to "en" but page still renders and gql query has missing locale causing an error.

## Checklist
* [x] Unit tests
* [x] E2E tests
* [x] Documentation
