### PR TITLE
Display order in correct currency.

### DIFF
--- a/src/components/common/BaseMoney/script.js
+++ b/src/components/common/BaseMoney/script.js
@@ -4,7 +4,11 @@ export default {
   },
   computed: {
     formattedMoney() {
-      return this.$n(this.amount, 'currency', this.$store.state.country);
+      const countryIsNotCurrency = {
+        USD: 'US',
+        EUR: 'DE',
+      };
+      return this.$n(this.amount, 'currency', countryIsNotCurrency[this.currency]);
     },
     amount() {
       if (this.money) {
@@ -12,5 +16,12 @@ export default {
       }
       return 0;
     },
+    currency() {
+      if (this.money) {
+        return this.money.currencyCode;
+      }
+      return '';
+    },
+
   },
 };

--- a/src/components/productdetail/ProductInfo/script.js
+++ b/src/components/productdetail/ProductInfo/script.js
@@ -61,6 +61,7 @@ export default {
         fragment printPrice on BaseMoney {
           centAmount
           fractionDigits
+          currencyCode
         }`,
       variables() {
         return {

--- a/tests/unit/specs/components/common/BaseMoney.spec.js
+++ b/tests/unit/specs/components/common/BaseMoney.spec.js
@@ -22,6 +22,7 @@ describe('BaseMoney/index.vue', () => {
         money: {
           centAmount: 1275,
           fractionDigits: 2,
+          currencyCode: 'EUR',
         },
       },
     };
@@ -36,7 +37,7 @@ describe('BaseMoney/index.vue', () => {
 
     // eslint-disable-next-line no-unused-expressions
     wrapper.vm.formattedPrice;
-    expect(options.mocks.$n).toHaveBeenCalledWith(12.75, 'currency', 'de-DE');
+    expect(options.mocks.$n).toHaveBeenCalledWith(12.75, 'currency', 'EUR');
   });
 
   it('calculates price amount with 2 fraction digit', () => {

--- a/tests/unit/specs/components/common/BaseMoney.spec.js
+++ b/tests/unit/specs/components/common/BaseMoney.spec.js
@@ -37,7 +37,7 @@ describe('BaseMoney/index.vue', () => {
 
     // eslint-disable-next-line no-unused-expressions
     wrapper.vm.formattedPrice;
-    expect(options.mocks.$n).toHaveBeenCalledWith(12.75, 'currency', 'EUR');
+    expect(options.mocks.$n).toHaveBeenCalledWith(12.75, 'currency', 'DE');
   });
 
   it('calculates price amount with 2 fraction digit', () => {


### PR DESCRIPTION
When switching country the oder switches prices, order should show the currency it was made in.

## Checklist
* [x] Unit tests
* [x] E2E tests
* [x] Documentation
