### PR TITLE
Do not use product types route.

### DIFF
--- a/src/api/products.js
+++ b/src/api/products.js
@@ -1,17 +1,20 @@
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-shadow */
 import {
-  withToken, groupFetchJson, makeConfig, toUrl, baseUrl,
-} from './api';
-import config from '../../sunrise.config';
-import productTypes from './productTypes';
-import { locale } from '../components/common/shared';
+  withToken,
+  groupFetchJson,
+  makeConfig,
+  toUrl,
+  baseUrl,
+} from "./api";
+import config from "../../sunrise.config";
+import { locale } from "../components/common/shared";
 
 const asAttribute = (name, type, locale) => {
-  if (type === 'lnum') {
+  if (type === "lnum") {
     return `variants.attributes.${name}.label.${locale}`;
   }
-  if (type === 'enum') {
+  if (type === "enum") {
     return `variants.attributes.${name}.key`;
   }
   return `variants.attributes.${name}`;
@@ -23,87 +26,94 @@ const asAttribute = (name, type, locale) => {
 //  {"filter.query":["variants.attributes.designer.key:\"rebel\",\"havaianas\""]}
 //  when 'designer' is the value of the name property of one of the items in
 //  vueConfig.facetSearches
-const facets = (query = {}, locale) => config.facetSearches
-  .reduce(
-    (result, { name, type }) => {
+const facets = (query = {}, locale) =>
+  config.facetSearches.reduce((result, { name, type }) => {
     // eslint-disable-next-line no-prototype-builtins
-      if (query.hasOwnProperty(name)) {
-        result['filter.query'] = result['filter.query'] || [];
-        result['filter.query'].push(
-          `${asAttribute(name, type, locale)}:${
-            Array.isArray(query[name])
-              ? query[name].map(
-                (value) => `"${value}"`,
-              ).join(',')
-              : `"${query[name]}"`
-          }`,
-        );
+    if (query.hasOwnProperty(name)) {
+      result["filter.query"] = result["filter.query"] || [];
+      result["filter.query"].push(
+        `${asAttribute(name, type, locale)}:${
+          Array.isArray(query[name])
+            ? query[name]
+                .map((value) => `"${value}"`)
+                .join(",")
+            : `"${query[name]}"`
+        }`
+      );
+    }
+    return result;
+  }, {});
+const setCategory = ({ category, ...query }) =>
+  category
+    ? {
+        ...query,
+        "filter.query": `categories.id:subtree("${category}")`,
       }
-      return result;
-    }, {},
-  );
-const setCategory = ({ category, ...query }) => (category
-  ? {
-    ...query,
-    'filter.query': `categories.id:subtree("${category}")`,
-  }
-  : query);
+    : query;
 
 const products = {
   get: withToken(
     (
-      [query, routeQuery, locale, totalFacets = config.facetSearches],
-      accessToken,
+      [
+        query,
+        routeQuery,
+        locale,
+        totalFacets = config.facetSearches,
+      ],
+      accessToken
     ) => {
       query = setCategory(query);
       return Promise.all([
         groupFetchJson(
-          toUrl(
-            `${baseUrl}/product-projections/search`,
-            [
-              ...Object.entries(query)
-                .filter(
-                  ([, val]) => !(val === null || val === undefined),
-                ).map(
-                  ([k, v]) => {
-                    if (k === 'priceFilter') {
-                      return ['filter.query', v];
-                    }
-                    return [k, v];
-                  },
-                ),
-              ...Object.entries(facets(routeQuery, locale)),
-              ...totalFacets.map(
-                ({ name, type }) => [
-                  'facet',
-                  `${asAttribute(name, type, locale)} counting products`,
-                ],
-              ),
-            ],
-          ),
-          makeConfig(accessToken),
-        ),
-        productTypes.translations(),
-      ]).then(
-        ([{ facets, ...result }, translation]) => ({
-          ...result,
-          facets: config.facetSearches.map(
-            ({ name, type }) => {
-              const facet = facets[asAttribute(name, type, locale)];
-              return ({
-                ...facet,
+          toUrl(`${baseUrl}/product-projections/search`, [
+            ...Object.entries(query)
+              .filter(
+                ([, val]) =>
+                  !(val === null || val === undefined)
+              )
+              .map(([k, v]) => {
+                if (k === "priceFilter") {
+                  return ["filter.query", v];
+                }
+                return [k, v];
+              }),
+            ...Object.entries(facets(routeQuery, locale)),
+            ...totalFacets.map(({ name, type }) => [
+              "facet",
+              `${asAttribute(
                 name,
-                label: translation[name]?.[locale] || name,
                 type,
-                terms: [...(facet?.terms || [])].sort(
-                  (a, b) => a.term.localeCompare(b.term),
-                ),
-              });
-            },
-          ),
-        }),
-      );
-    },
+                locale
+              )} counting products`,
+            ]),
+          ]),
+          makeConfig(accessToken)
+        ),
+        config.facetSearches.reduce((result, item) => {
+          result[item.name] = item.label;
+          return result;
+        }, {}),
+      ]).then(([{ facets, ...result }, translation]) => ({
+        ...result,
+        facets: config.facetSearches.map(
+          ({ name, type }) => {
+            const facet =
+              facets[asAttribute(name, type, locale)];
+            return {
+              ...facet,
+              name,
+              label: translation[name]?.[locale] || name,
+              type,
+              terms: [
+                ...(facet?.terms || []),
+              ].sort((a, b) =>
+                a.term.localeCompare(b.term)
+              ),
+            };
+          }
+        ),
+      }));
+    }
   ),
   facets: (query, routeQuery, locale) => {
     query = {
@@ -112,33 +122,30 @@ const products = {
       pageSize: 0,
     };
     return Promise.all(
-      config.facetSearches.map(
-        ({ name, component }) => {
-          const newRouteQuery = { ...routeQuery };
-          delete newRouteQuery[name];
-          return products.get([
+      config.facetSearches.map(({ name, component }) => {
+        const newRouteQuery = { ...routeQuery };
+        delete newRouteQuery[name];
+        return products
+          .get([
             query,
             newRouteQuery,
             locale,
             config.facetSearches.filter(
-              (f) => f.name === name,
+              (f) => f.name === name
             ),
           ])
-            .then(
-              ({ facets }) => ({
-                ...facets
-                  .find((f) => f.name === name),
-                component,
-              }),
-            );
-        },
-      ),
+          .then(({ facets }) => ({
+            ...facets.find((f) => f.name === name),
+            component,
+          }));
+      })
     );
   },
   paramsFromComponent: (component) => {
-    const category = component.$route.params.categorySlug === 'all'
-      ? undefined
-      : component.categories?.results[0]?.id;
+    const category =
+      component.$route.params.categorySlug === "all"
+        ? undefined
+        : component.categories?.results[0]?.id;
     const route = component.$route;
     const {
       currency,
@@ -153,12 +160,16 @@ const products = {
       ? { [`text.${loc}`]: route.query.q }
       : {};
     const sort = sortValue
-      ? { sort: `lastModifiedAt ${sortValue === 'newest' ? 'desc' : 'asc'}` }
+      ? {
+          sort: `lastModifiedAt ${
+            sortValue === "newest" ? "desc" : "asc"
+          }`,
+        }
       : {};
     const { min, max } = route.query;
     const priceFilter = {};
-    const minQ = min ? min * 100 : '0';
-    const maxQ = max ? max * 100 : '100000000';
+    const minQ = min ? min * 100 : "0";
+    const maxQ = max ? max * 100 : "100000000";
     priceFilter.priceFilter = `variants.scopedPrice.value.centAmount: range (${minQ} to ${maxQ})`;
     return {
       category,

--- a/sunrise.config.js
+++ b/sunrise.config.js
@@ -73,12 +73,34 @@ export default {
     salesExternalId: "6",
   },
   facetSearches: [
-    { name: "size", type: "text" },
-    { name: "color", type: "lnum", component: "colors" },
+    {
+      name: "size",
+      type: "text",
+      label: {
+        it: "Size",
+        de: "Größe",
+        en: "Size",
+      },
+    },
+    {
+      name: "color",
+      type: "lnum",
+      component: "colors",
+      label: {
+        de: "Farbe",
+        it: "Color",
+        en: "Color",
+      },
+    },
     {
       name: "designer",
       type: "enum",
       component: "designer",
+      label: {
+        it: "Designer",
+        de: "Designer",
+        en: "Designer",
+      },
     },
   ],
   detailAttributes: [


### PR DESCRIPTION
## Checklist
* [x] Unit tests
* [x] E2E tests
* [x] Documentation

Remove fetching product types, this info can be stored in sunrise.config. Motivation: Need view_products scope but merchant center create api profile for web/mobile does not have this. Currently product_types are only fetched for translations of attributes for the facet search.