### PR TITLE
case insensitive locale on url

### DIFF
--- a/src/components/common/shared.js
+++ b/src/components/common/shared.js
@@ -96,7 +96,17 @@ export const changeRoute = (route, component, push = true, keepScrollPosition = 
     );
   }
 };
-export const locale = (component) => component?.$route?.params?.locale;
+export const locale = (component) => {
+  //get case insensitive locale from sunrise config
+  const loc = //locale from url to upper case
+  (component?.$route?.params?.locale || "").toUpperCase();
+  const [, fromConfig] =
+    Object.keys(config.languages)
+      //all locale keys from config in [UPPERCASE,org]
+      .map((key) => [key.toUpperCase(), key])
+      .find(([key]) => key === loc) || []; //find the one from url
+  return fromConfig; //return value from config (in correct case)
+};
 export const isToughDevice = () => 'ontouchstart' in window;
 export const modifyQuery = (key, value, query, add = true) => {
   const values = [value]

--- a/src/components/root/root.js
+++ b/src/components/root/root.js
@@ -72,7 +72,10 @@ export default {
     if (this?.$store?.state?.country !== this.$route.params.country) {
       this.$store.dispatch('setCountry', this.$route.params.country);
     }
-    if (this?.$store?.state?.locale !== loc(this)) {
+    if (
+      this?.$store?.state?.locale !==
+      this.$route?.params?.locale
+    ) {
       this.$store.dispatch('setLocale', loc(this));
     }
     checkLocale(this);


### PR DESCRIPTION
## Checklist
* [x] Unit tests
* [x] E2E tests
* [x] Documentation

When url has en or EN it should not matter but correct locale should be saved in store state or the code is [unable to get localised values](https://github.com/commercetools/sunrise-spa/blob/master/src/components/productoverview/ProductList/ProductList.js#L108-L109).